### PR TITLE
only preload public posts; resolves #17

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2966,7 +2966,11 @@ function wp_cron_preload_cache() {
 	}
 
 	if ( $wp_cache_preload_posts == 'all' || $c < $wp_cache_preload_posts ) {
-		$posts = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE ( post_type != 'revision' AND post_type != 'nav_menu_item' ) AND post_status = 'publish' ORDER BY ID ASC LIMIT $c, 100" );
+		$types = get_post_types( array( 'public' => true, 'publicly_queryable' => true ), 'names', 'or' );
+		unset( $types['attachment'] );
+		$types = array_map( 'esc_sql', $types );
+		$types = "'" . implode( "','", $types ) . "'";
+		$posts = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE ( post_type IN ( $types ) ) AND post_status = 'publish' ORDER BY ID ASC LIMIT $c, 100" );
 		wp_cache_debug( "wp_cron_preload_cache: got 100 posts from position $c.", 5 );
 	} else {
 		wp_cache_debug( "wp_cron_preload_cache: no more posts to get. Limit ($wp_cache_preload_posts) reached.", 5 );


### PR DESCRIPTION
Resolves #17 

* fetch a list of post types that can be accessed from the front end;
* exclude `attachment` post type from the list;
* fetch IDs of posts in the remaining post types that have status `publish`