### PR TITLE
Fixed - Fatal error: Internal Zend error - Missing class information

### DIFF
--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -2,12 +2,7 @@
 $known_headers = array("Last-Modified", "Expires", "Content-Type", "Content-type", "X-Pingback", "ETag", "Cache-Control", "Pragma");
 
 if (!class_exists('CacheMeta')) {
-	class CacheMeta {
-		var $dynamic = false;
-		var $headers = array();
-		var $uri = '';
-		var $post = 0;
-	}
+	require_once( 'wp-cache-cachemeta.php' );
 }
 
 $WPSC_HTTP_HOST = htmlentities( $_SERVER[ 'HTTP_HOST' ] );

--- a/wp-cache-cachemeta.php
+++ b/wp-cache-cachemeta.php
@@ -1,0 +1,8 @@
+<?php
+class CacheMeta
+{
+    var $dynamic = false;
+    var $headers = array ();
+    var $uri = '';
+    var $post = 0;
+}


### PR DESCRIPTION
I had the same error as the following post: https://wordpress.org/support/topic/plugin-wp-super-cache-error-zend-on-gandi-hosting

Excluding the file from APC seems a bit to much trouble so i made this solution.

Can anybody confirm that this fixes the issue.

PHP: 5.3.10
APC: 3.1.7
