### PR TITLE
set url path for ossdl_off_cdn_url and ossdl_off_blog_url to home url

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -4,8 +4,8 @@
 
 /* Set up some defaults */
 if ( get_option( 'ossdl_off_cdn_url' ) == false )
-	add_option('ossdl_off_cdn_url', get_option('siteurl'));
-$ossdl_off_blog_url = get_option('siteurl');
+	add_option('ossdl_off_cdn_url', get_home_url());
+$ossdl_off_blog_url = get_home_url();
 $ossdl_off_cdn_url = trim( get_option('ossdl_off_cdn_url') );
 if ( get_option( 'ossdl_off_include_dirs' ) == false )
 	add_option('ossdl_off_include_dirs', 'wp-content,wp-includes');
@@ -145,7 +145,7 @@ function scossdl_off_options() {
 	$example_cnames .= ',' . str_replace( 'http://cdn.', 'http://cdn2.', $example_cdn_uri );
 	$example_cnames .= ',' . str_replace( 'http://cdn.', 'http://cdn3.', $example_cdn_uri );
 
-	$example_cdn_uri = get_option('ossdl_off_cdn_url') == get_option('siteurl') ? $example_cdn_uri : get_option('ossdl_off_cdn_url');
+	$example_cdn_uri = get_option('ossdl_off_cdn_url') == get_home_url() ? $example_cdn_uri : get_option('ossdl_off_cdn_url');
 	$example_cdn_uri .= '/wp-includes/js/prototype.js';
 	?>
 		<p><?php _e( 'Your website probably uses lots of static files. Image, Javascript and CSS files are usually static files that could just as easily be served from another site or CDN. Therefore this plugin replaces any links in the <code>wp-content</code> and <code>wp-includes</code> directories (except for PHP files) on your site with the URL you provide below. That way you can either copy all the static content to a dedicated host or mirror the files to a CDN by <a href="http://knowledgelayer.softlayer.com/questions/365/How+does+Origin+Pull+work%3F" target="_blank">origin pull</a>.', 'wp-super-cache' ); ?></p>


### PR DESCRIPTION
Sets the URL path for CDN replacement to the front end URL of the site, instead of the backend.

This fixes an error on sites using a separate Site URL for the Administration Panels than the front end. For example, in [WordPress Skeleton](https://github.com/markjaquith/WordPress-Skeleton), the WordPress core files are put into the `/wp` directory, and can be accessed at http://mysite.com/wp. When the OSSDL off-linker goes to alter asset links to the off-site URL, it does not find any proper links. In this example, it is looking for mysite.com/**wp/**wp-content/file.jpg instead of mysite.com/wp-content/file.jpg.
