### PR TITLE
Do not show WP Super Cache broken message for AJAX, REST, or XMLRPC requests

### DIFF
--- a/advanced-cache.php
+++ b/advanced-cache.php
@@ -5,8 +5,14 @@ function wpcache_broken_message() {
 	if ( isset( $wp_cache_config_file ) == false )
 		return '';
 
-	if ( false == strpos( $_SERVER[ 'REQUEST_URI' ], 'wp-admin' ) )
+	$doing_ajax =     defined( 'DOING_AJAX' ) && DOING_AJAX;
+	$xmlrpc_request = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
+	$rest_request =   defined( 'REST_REQUEST' ) && REST_REQUEST;
+
+	$skip_output = ( $doing_ajax || $xmlrpc_request || $rest_request );
+	if ( false == strpos( $_SERVER[ 'REQUEST_URI' ], 'wp-admin' ) && !$skip_output ) {
 		echo "<!-- WP Super Cache is installed but broken. The constant WPCACHEHOME must be set in the file wp-config.php and point at the WP Super Cache plugin directory. -->";
+	}
 }
 
 if ( false == defined( 'WPCACHEHOME' ) ) {


### PR DESCRIPTION
Fixes #36