### PR TITLE
Fix blank page if cache is on and page shouldn't be cached

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -148,7 +148,7 @@ function wp_cache_get_response_headers() {
 function wp_cache_is_rejected($uri) {
 	global $cache_rejected_uri;
 
-	$auto_rejected = array( '/wp-admin/', 'xmlrpc.php', 'wp-app.php' , '/testinlagg-i-natt/' );
+	$auto_rejected = array( '/wp-admin/', 'xmlrpc.php', 'wp-app.php' );
 	foreach( $auto_rejected as $u ) {
 		if( strstr( $uri, $u ) )
 			return true; // we don't allow caching of wp-admin for security reasons
@@ -272,9 +272,6 @@ function wp_cache_ob_callback( $buffer ) {
 	} elseif ( isset( $_GET[ 'preview' ] ) ) {
 		wp_cache_debug( 'Not caching preview post.', 2 );
 		$cache_this_page = false;
-/*	} elseif ( !in_array($script, $cache_acceptable_files) && wp_cache_is_rejected( $wp_cache_request_uri ) ) {
-		wp_cache_debug( 'URI rejected. Not Caching', 2 );
-		$cache_this_page = false;*/
 	} elseif ( wp_cache_user_agent_is_rejected() ) {
 		wp_cache_debug( "USER AGENT ({$_SERVER[ 'HTTP_USER_AGENT' ]}) rejected. Not Caching", 4 );
 		$cache_this_page = false;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -50,6 +50,10 @@ function wp_cache_phase2() {
 		wp_cache_debug( 'Not caching wp-admin requests.', 5 );
 		return false;
 	}
+	elseif ( $_SERVER["REQUEST_METHOD"] == 'POST' || !empty( $_POST ) || get_option( 'gzipcompression' ) ) {
+		wp_cache_debug( 'Not caching POST request.', 5 );
+		return false;
+	}
 
 	if ( !empty( $_GET ) && !defined( "DOING_CRON" ) ) {
 		wp_cache_debug( 'Supercache caching disabled. Only using wp-cache. Non empty GET request. ' . serialize( $_GET ), 5 );
@@ -256,9 +260,9 @@ function wp_cache_ob_callback( $buffer ) {
 	} elseif ( $wp_cache_no_cache_for_get && false == empty( $_GET ) && false == defined( 'DOING_CRON' ) ) {
 		wp_cache_debug( "Non empty GET request. Caching disabled on settings page. " . serialize( $_GET ), 1 );
 		$cache_this_page = false;
-	} elseif ( $_SERVER["REQUEST_METHOD"] == 'POST' || !empty( $_POST ) || get_option( 'gzipcompression' ) ) {
+	/*} elseif ( $_SERVER["REQUEST_METHOD"] == 'POST' || !empty( $_POST ) || get_option( 'gzipcompression' ) ) {
 		wp_cache_debug( 'Not caching POST request.', 5 );
-		$cache_this_page = false;
+		$cache_this_page = false;*/
 	} elseif ( $wp_cache_object_cache && !empty( $_GET ) ) {
 		wp_cache_debug( 'Not caching GET request while object cache storage enabled.', 5 );
 		$cache_this_page = false;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -46,6 +46,7 @@ function wp_cache_phase2() {
 		do_cacheaction( 'add_cacheaction' );
 	}
 
+	// never store admin and POST requests 
 	if ( is_admin() ) {
 		wp_cache_debug( 'Not caching wp-admin requests.', 5 );
 		return false;
@@ -260,9 +261,6 @@ function wp_cache_ob_callback( $buffer ) {
 	} elseif ( $wp_cache_no_cache_for_get && false == empty( $_GET ) && false == defined( 'DOING_CRON' ) ) {
 		wp_cache_debug( "Non empty GET request. Caching disabled on settings page. " . serialize( $_GET ), 1 );
 		$cache_this_page = false;
-	/*} elseif ( $_SERVER["REQUEST_METHOD"] == 'POST' || !empty( $_POST ) || get_option( 'gzipcompression' ) ) {
-		wp_cache_debug( 'Not caching POST request.', 5 );
-		$cache_this_page = false;*/
 	} elseif ( $wp_cache_object_cache && !empty( $_GET ) ) {
 		wp_cache_debug( 'Not caching GET request while object cache storage enabled.', 5 );
 		$cache_this_page = false;
@@ -309,12 +307,13 @@ function wp_cache_ob_callback( $buffer ) {
 
 	if ( !isset( $wp_query ) )
 		wp_cache_debug( 'wp_cache_ob_callback: WARNING! $query not defined but the plugin has worked around that problem.', 4 );
+	
+	$buffer = wp_cache_get_ob( $buffer );
 
 	if ( $cache_this_page ) {
 
 		wp_cache_debug( 'Output buffer callback', 4 );
 
-		$buffer = wp_cache_get_ob( $buffer );
 		wp_cache_shutdown_callback();
 		return $buffer;
 	} else {


### PR DESCRIPTION
As I wrote in #52, the user was served a blank page if he/she entered wrong password at login. I also realized that if a page cache was on, the page shouldn't be cached, and there isn't a cache stored the user is served a blank page. 

This behavior was because wp_cache_maybe_dynamic was called with an undefined variable and this pull request fixes that.