### PR TITLE
When pre-loading, start with the newest post as the documentation says

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3003,7 +3003,7 @@ function wp_cron_preload_cache() {
 		$types = get_post_types( array( 'public' => true, 'publicly_queryable' => true ), 'names', 'or' );
 		$types = array_map( 'esc_sql', $types );
 		$types = "'" . implode( "','", $types ) . "'";
-		$posts = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE ( post_type IN ( $types ) ) AND post_status = 'publish' ORDER BY ID ASC LIMIT $c, 100" );
+		$posts = $wpdb->get_col( "SELECT ID FROM {$wpdb->posts} WHERE ( post_type IN ( $types ) ) AND post_status = 'publish' ORDER BY ID DESC LIMIT $c, 100" );
 		wp_cache_debug( "wp_cron_preload_cache: got 100 posts from position $c.", 5 );
 	} else {
 		wp_cache_debug( "wp_cron_preload_cache: no more posts to get. Limit ($wp_cache_preload_posts) reached.", 5 );


### PR DESCRIPTION
The help content on the Preloading page states:

"Preloading creates lots of files however. Caching is done from the newest post to the oldest so please consider only caching the newest if you have lots (10,000+) of posts. This is especially important on shared hosting."

This seems a good approach, however currently the code picks post "oldest" first, not "newest". This PR amends things to pick the "newest" posts to preload first.

\* The current definition of "newest" or "oldest" is actually based on post ID, and this PR maintains that, albeit swapping the ordering. However ordering by post_modified might actually be better - happy to revise this PR if you agree. 
