### PR TITLE
Fix lay-out on settings pages

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -753,9 +753,8 @@ jQuery(document).ready(function(){
 #nav h2 {
 	border-bottom: 1px solid #ccc;
 	padding-bottom: 0;
-}
-table.wpsc-settings-table {
-	clear: both;
+	float: left;
+	width: 100%;
 }
 </style>
 <?php
@@ -806,7 +805,7 @@ table.wpsc-settings-table {
 		update_cached_mobile_ua_list( $wp_cache_mobile_browsers, $wp_cache_mobile_prefixes, $mobile_groups );
 	}
 
-	?> <table class="wpsc-settings-table"><td valign='top'><?php
+	?> <table><td valign='top'><?php
 	switch( $_GET[ 'tab' ] ) {
 		case "cdn":
 		scossdl_off_options();


### PR DESCRIPTION
Lay-out on settings page remains broken, even after https://github.com/Automattic/wp-super-cache/commit/ff1e165f1521e61176291b43c63a4c272f826f70. Grey line which should be below the tabs, is visible above the tabs.