### PR TITLE
Properly serve 304 errors

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -232,15 +232,15 @@ function wp_cache_serve_cache_file() {
 			if ( $wp_cache_mfunc_enabled == 0 && $wp_supercache_304 ) {
 				if ( function_exists( 'apache_request_headers' ) ) {
 					$request = apache_request_headers();
-					$remote_mod_time = ( isset ( $request[ 'If-Modified-Since' ] ) ) ? $request[ 'If-Modified-Since' ] : 0;
+					$remote_mod_time = ( isset ( $request[ 'If-Modified-Since' ] ) ) ? $request[ 'If-Modified-Since' ] : null;
 				} else {
 					if ( isset( $_SERVER[ 'HTTP_IF_MODIFIED_SINCE' ] ) )
 						$remote_mod_time = $_SERVER[ 'HTTP_IF_MODIFIED_SINCE' ];
 					else
-						$remote_mod_time = 0;
+						$remote_mod_time = null;
 				}
 				$local_mod_time = gmdate("D, d M Y H:i:s",filemtime( $file )).' GMT';
-				if ( $remote_mod_time != 0 && $remote_mod_time == $local_mod_time ) {
+				if ( !is_null($remote_mod_time) && $remote_mod_time == $local_mod_time ) {
 					header("HTTP/1.0 304 Not Modified");
 					exit();
 				}


### PR DESCRIPTION
Due to PHP type-matching, "$remote_mod_time != 0" is always FALSE, so a 304 header would never be served. This fixes the issue so that 304 headers are properly served.