### PR TITLE
Defined some global vars used to prevent warnings with wp-cli

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -34,6 +34,7 @@ if( !defined('WP_CONTENT_URL') )
 if( !defined('WP_CONTENT_DIR') )
 	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
 
+global $wp_cache_config_file, $wp_cache_link, $cache_path;
 $wp_cache_config_file = WP_CONTENT_DIR . '/wp-cache-config.php';
 
 if ( !defined( 'WPCACHEHOME' ) ) {


### PR DESCRIPTION
Defined some global vars for prevent warning with wp-cli or other CLI scripts that uses wordpress. Probably exists other global vars to be defined.