### PR TITLE
Fix front-page invalidation incorrect

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1191,7 +1191,7 @@ function wp_cache_post_change( $post_id ) {
 		} else {
 			wp_cache_debug( "wp_cache_post_change: not deleting all pages.", 4 );
 		}
-		if( $all == true && get_option( 'show_on_front' ) == 'page' ) {
+		if( $all == true && get_option( 'show_on_front' ) == 'posts' ) {
 			wp_cache_debug( "Post change: deleting page_on_front and page_for_posts pages.", 4 );
 			wp_cache_debug( "Post change: page_on_front " . get_option( 'page_on_front' ), 4 );
 			wp_cache_post_id_gc( $siteurl, get_option( 'page_on_front' ), 'single' );


### PR DESCRIPTION
As far as I can see, this is deleting the front page cache when it is a static page rather than when it is a blog page.

This fix makes it delete the front page cache when the front page is a blog and not when it is a static page.
