### PR TITLE
Do not attempt to serve wp-admin requests

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -125,6 +125,11 @@ function wp_cache_serve_cache_file() {
 
 	extract( wp_super_cache_init() );
 
+	if ( is_admin() ) {
+		wp_cache_debug( 'Not serving wp-admin requests.', 5 );
+		return false;
+	}
+
 	if ( wp_cache_user_agent_is_rejected() ) {
 		wp_cache_debug( "No wp-cache file served as user agent rejected.", 5 );
 		return false;

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -123,8 +123,6 @@ function wp_cache_serve_cache_file() {
 	global $wp_cache_object_cache, $cache_compression, $wp_cache_slash_check, $wp_supercache_304, $wp_cache_home_path, $wp_cache_no_cache_for_get;
 	global $wp_cache_disable_utf8, $wp_cache_mfunc_enabled;
 
-	extract( wp_super_cache_init() );
-
 	if ( is_admin() ) {
 		wp_cache_debug( 'Not serving wp-admin requests.', 5 );
 		return false;
@@ -139,6 +137,8 @@ function wp_cache_serve_cache_file() {
 		wp_cache_debug( "Non empty GET request. Caching disabled on settings page. " . json_encode( $_GET ), 1 );
 		return false;
 	}
+
+	extract( wp_super_cache_init() );
 
 	if ( $wp_cache_object_cache && wp_cache_get_cookies_values() == '' ) {
 		if ( !empty( $_GET ) ) {


### PR DESCRIPTION
Phase 2 does not create cache files for wp-admin requests.

This fix short-cuts the serving of these non-existent files and avoids cluttering up the log file with them.
