### PR TITLE
Avoid rejecting cache for root pages

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -137,6 +137,9 @@ function wp_cache_get_response_headers() {
 
 function wp_cache_is_rejected($uri) {
 	global $cache_rejected_uri;
+	
+	// If uri is '' or '/' it will always match $auto_rejected
+	if ( $uri == '' || $uri == '/') return false;
 
 	$auto_rejected = array( '/wp-admin/', 'xmlrpc.php', 'wp-app.php' );
 	foreach( $auto_rejected as $u ) {


### PR DESCRIPTION
For home page $uri is either '' or '/' which will always be rejected.

So for these we will return false and leave it to other checks to avoid caching if needed.

Part 2 of 2 to address Automattic/wp-super-cache#959
