### PR TITLE
Remove `flush()` call in wp_cache_get_response_headers()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -121,7 +121,6 @@ if ( !function_exists( 'wp_cache_user_agent_is_rejected' ) ) {
 
 function wp_cache_get_response_headers() {
 	if(function_exists('apache_response_headers')) {
-		flush();
 		$headers = apache_response_headers();
 	} else if(function_exists('headers_list')) {
 		$headers = array();


### PR DESCRIPTION
For more details see: https://github.com/Automattic/wp-super-cache/issues/126

Fixes #126
