### PR TITLE
Fix the bottom-border in admin menu

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -753,6 +753,7 @@ jQuery(document).ready(function(){
 #nav h2 {
 	border-bottom: 1px solid #ccc;
 	padding-bottom: 0;
+	height: 2em;
 }
 table.wpsc-settings-table {
 	clear: both;


### PR DESCRIPTION
Added height to h2 element after line 755. Fixing the issue where border-bottom shows at the top of admin tabs.
