### PR TITLE
line 392 change to array() to avoid a PHP 7.1 error

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -389,7 +389,7 @@ function wp_cache_get_ob(&$buffer) {
 		$wp_cache_mfunc_enabled = 0;
 
 	$new_cache = true;
-	$wp_cache_meta = '';
+	$wp_cache_meta = array();
 
 	/* Mode paranoic, check for closing tags 
 	 * we avoid caching incomplete files */


### PR DESCRIPTION
This seems to fix the error I reported at https://github.com/Automattic/wp-super-cache/issues/156

Props to Otto for the code.