### PR TITLE
Disable caching in customize preview

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -47,8 +47,9 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon )
 
 do_cacheaction( 'cache_init' );
 
-if (!$cache_enabled || $_SERVER["REQUEST_METHOD"] == 'POST')
+if ( ! $cache_enabled || $_SERVER["REQUEST_METHOD"] == 'POST' || isset( $_GET['customize_changeset_uuid'] ) ) {
 	return true;
+}
 
 $file_expired = false;
 $cache_filename = '';


### PR DESCRIPTION
This is a first stab at ensuring compatibility with the customizer. 

A bug report for 4.7 seems to indicate it is not compatible: https://core.trac.wordpress.org/ticket/39128

I'm trying to pin down where the problem lies exactly, but here's an initial stab at compatibility.