### PR TITLE
Check that header parts exist to avoid `Undefined Index` notices

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -126,7 +126,10 @@ function wp_cache_get_response_headers() {
 	} else if(function_exists('headers_list')) {
 		$headers = array();
 		foreach(headers_list() as $hdr) {
-			list($header_name, $header_value) = explode(': ', $hdr, 2);
+			$header_parts = explode( ':', $hdr, 2 );
+			$header_name  = isset( $header_parts[0] ) ? trim( $header_parts[0] ) : '';
+			$header_value = isset( $header_parts[1] ) ? trim( $header_parts[1] ) : '';
+
 			$headers[$header_name] = $header_value;
 		}
 	} else


### PR DESCRIPTION
Previously, a header with an empty value would trigger a PHP notice, because `list()` was trying to access index `1` of the array returned by `explode()`, but the index didn't exist.

For example `Last-Modified:` would trigger the notice, and result in a `$headers` entry like this: `[Last-Modified:] => null`. Note the `:` incorrectly placed in the header name.

Because this function is called frequently, the notice clutters logs, and is disruptive to developers with `WP_DEBUG` enabled.

This commit checks to make sure there's a value before trying to access it. That avoids the notice, and results in `$headers` entry like: `[Last-Modified] => ''`, without the invalid `:`.

Valid headers are unaffected by the change.