### PR TITLE
Remove a stray bracket from the no-jetpack-installed notice

### DIFF
--- a/plugins/jetpack.php
+++ b/plugins/jetpack.php
@@ -25,7 +25,7 @@ function wp_super_cache_jetpack_admin() {
 	<h4><?php _e( 'Jetpack Mobile Theme', 'wp-super-cache' ); ?></h4>
 	<?php
 	if ( false == file_exists( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' ) ) {
-		echo "<strong>" . sprintf( __( "Jetpack not found in %s. Install it and enable the mobile theme and this helper plugin to cache visits by mobile visitors." ), dirname( WPCACHEHOME ) ) . "</strong>>";
+		echo "<strong>" . sprintf( __( "Jetpack not found in %s. Install it and enable the mobile theme and this helper plugin to cache visits by mobile visitors." ), dirname( WPCACHEHOME ) ) . "</strong>";
 	} else { ?>
 		<form name="wp_manager" action="" method="post">
 		<label><input type="radio" name="cache_jetpack" value="1" <?php if( $cache_jetpack ) { echo 'checked="checked" '; } ?>/> <?php _e( 'Enabled', 'wp-super-cache' ); ?></label>


### PR DESCRIPTION
Just noticed that the Jetpack notice had a trailing `>` after it, which was from a typo'd `</strong>` tag.