### PR TITLE
No need to delete the "page_on_front" as it's already done

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1206,7 +1206,6 @@ function wp_cache_post_change( $post_id ) {
 	if( $all == true && get_option( 'show_on_front' ) == 'page' ) {
 		wp_cache_debug( "Post change: deleting page_on_front and page_for_posts pages.", 4 );
 		wp_cache_debug( "Post change: page_on_front " . get_option( 'page_on_front' ), 4 );
-		wp_cache_post_id_gc( $siteurl, get_option( 'page_on_front' ), 'single' );
 		$permalink = trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( get_option( 'page_for_posts' ) ) ) );
 		$files_to_check = get_all_supercache_filenames( $dir . $permalink );
 		foreach( $files_to_check as $cache_file ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1133,21 +1133,19 @@ function wp_cache_post_id_gc( $siteurl, $post_id, $all = 'all' ) {
 	$permalink = trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( $post_id ) ) );
 	$dir = get_current_url_supercache_dir( $post_id );
 	wp_cache_debug( "wp_cache_post_id_gc post_id: $post_id " . get_permalink( $post_id ) . " clearing cache in $dir.", 4 );
-	if ( $all == 'all' ) {
+	if ( $all ) {
 		prune_super_cache( $dir, true, true );
 		do_action( 'gc_cache', 'prune', $permalink );
 		@rmdir( $dir );
+		wp_cache_debug( "wp_cache_post_id_gc clearing cache in {$supercache_home}page/." );
+		$supercache_home = get_supercache_dir();
+		prune_super_cache( $supercache_home . 'page/', true );
+		do_action( 'gc_cache', 'prune', 'page/' );
 	} else {
 		wp_cache_debug( "wp_cache_post_id_gc clearing cached index files in $dir.", 4 );
 		prune_super_cache( $dir, true, true ); 
 		do_action( 'gc_cache', 'prune', $permalink );
 	}
-	wp_cache_debug( "wp_cache_post_id_gc clearing cache in {$dir}/page/.", 4 );
-	prune_super_cache( $dir . '/page/', true );
-	$supercache_home = get_supercache_dir();
-	wp_cache_debug( "wp_cache_post_id_gc clearing cache in {$supercache_home}/page/.", 4 );
-	prune_super_cache( $supercache_home . '/page/', true );
-	do_action( 'gc_cache', 'prune', '/page/' );
 }
 
 function wp_cache_post_change( $post_id ) {
@@ -1182,6 +1180,11 @@ function wp_cache_post_change( $post_id ) {
 		$all = true;
 	}
 
+	$all_backup = $all;
+	$all = apply_filters( 'wpsc_delete_related_pages_on_edit', $all ); // return 0 to disable deleting homepage and other pages.
+	if ( $all != $all_backup )
+		wp_cache_debug( 'wp_cache_post_change: $all changed by wpsc_delete_related_pages_on_edit filter: ' . intval( $all ) );
+
 	if ( $wp_cache_object_cache )
 		reset_oc_version();
 
@@ -1191,7 +1194,7 @@ function wp_cache_post_change( $post_id ) {
 	$dir = get_supercache_dir();
 	$siteurl = trailingslashit( strtolower( preg_replace( '/:.*$/', '', str_replace( 'https://', '', str_replace( 'http://', '', get_option( 'home' ) ) ) ) ) );
 	// make sure the front page has a rebuild file
-	wp_cache_post_id_gc( $siteurl, $post_id );
+	wp_cache_post_id_gc( $siteurl, $post_id, $all );
 	if ( $all == true ) {
 		wp_cache_debug( "Post change: supercache enabled: deleting cache files in " . $cache_path . 'supercache/' . $siteurl, 4 );
 		$files_to_check = get_all_supercache_filenames( $dir );


### PR DESCRIPTION
Fixes #169
This call to wp_cache_post_id_gc() would recursively delete every cached
page on a site because "page_on_front" points at the homepage, not at
the original URL of the page.
This only happens on sites where the front page is a static page.