### PR TITLE
Store legacy cache files in the supercache directory.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -153,7 +153,15 @@ function wp_cache_serve_cache_file() {
 			wp_cache_debug( "Meta array from object cache corrupt. Ignoring cache.", 1 );
 			return true;
 		}
-	} elseif ( file_exists( $cache_file ) ) {
+	} elseif ( file_exists( $cache_file ) || file_exists( get_current_url_supercache_dir() . 'meta/' . $cache_filename ) ) {
+		if ( file_exists( get_current_url_supercache_dir() . 'meta/' . $cache_filename ) ) {
+			$cache_file = get_current_url_supercache_dir() . $cache_filename;
+			$meta_pathname = get_current_url_supercache_dir() . 'meta/' . $cache_filename;
+		} elseif ( !file_exists( $cache_file ) ) {
+			wp_cache_debug( "wp_cache_serve_cache_file: found cache file but then it disappeared!" );
+			return false;
+		}
+
 		wp_cache_debug( "wp-cache file exists: $cache_file", 5 );
 		if ( !( $meta = json_decode( wp_cache_get_legacy_cache( $meta_pathname ), true ) ) ) {
 			wp_cache_debug( "couldn't load wp-cache meta file", 5 );
@@ -165,7 +173,7 @@ function wp_cache_serve_cache_file() {
 			@unlink( $cache_file );
 			return true;
 		}
-	} else {
+	} else { // no $cache_file
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host
 		$filename = supercache_filename();
 		$file = get_current_url_supercache_dir() . $filename;

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -153,10 +153,10 @@ function wp_cache_serve_cache_file() {
 			wp_cache_debug( "Meta array from object cache corrupt. Ignoring cache.", 1 );
 			return true;
 		}
-	} elseif ( file_exists( $cache_file ) || file_exists( get_current_url_supercache_dir() . 'meta/' . $cache_filename ) ) {
-		if ( file_exists( get_current_url_supercache_dir() . 'meta/' . $cache_filename ) ) {
+	} elseif ( file_exists( $cache_file ) || file_exists( get_current_url_supercache_dir() . 'meta-' . $cache_filename ) ) {
+		if ( file_exists( get_current_url_supercache_dir() . 'meta-' . $cache_filename ) ) {
 			$cache_file = get_current_url_supercache_dir() . $cache_filename;
-			$meta_pathname = get_current_url_supercache_dir() . 'meta/' . $cache_filename;
+			$meta_pathname = get_current_url_supercache_dir() . 'meta-' . $cache_filename;
 		} elseif ( !file_exists( $cache_file ) ) {
 			wp_cache_debug( "wp_cache_serve_cache_file: found cache file but then it disappeared!" );
 			return false;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -930,15 +930,15 @@ function wp_cache_shutdown_callback() {
 		}
 
 		$serial = '<?php die(); ?>' . json_encode( $wp_cache_meta );
-		$dir = get_current_url_supercache_dir() . "meta/";
+		$dir = get_current_url_supercache_dir();
 		if( @is_dir( $dir ) == false )
 			@wp_mkdir_p( $dir );
 
 		if( wp_cache_writers_entry() ) {
-			wp_cache_debug( "Writing meta file: {$dir}{$meta_file}", 2 );
+			wp_cache_debug( "Writing meta file: {$dir}meta-{$meta_file}", 2 );
 			if ( false == $wp_cache_object_cache ) {
 				$tmp_meta_filename = $dir . uniqid( mt_rand(), true ) . '.tmp';
-				$final_meta_filename = $dir . $meta_file;
+				$final_meta_filename = $dir . "meta-" . $meta_file;
 				$fr = @fopen( $tmp_meta_filename, 'w');
 				if ( $fr ) {
 					fputs($fr, $serial);
@@ -960,7 +960,7 @@ function wp_cache_shutdown_callback() {
 			wp_cache_writers_exit();
 		}
 	} else {
-		wp_cache_debug( "Did not write meta file: $meta_file *$supercacheonly* *$wp_cache_not_logged_in* *$new_cache*", 2 );
+		wp_cache_debug( "Did not write meta file: meta-{$meta_file} *$supercacheonly* *$wp_cache_not_logged_in* *$new_cache*", 2 );
 	}
 	global $time_to_gc_cache;
 	if( isset( $time_to_gc_cache ) && $time_to_gc_cache == 1 ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -629,16 +629,16 @@ function wp_cache_get_ob(&$buffer) {
 			$supercacheonly = false;
 			fclose($fr);
 			if ( filesize( $tmp_wpcache_filename ) == 0 ) {
-				wp_cache_debug( "Warning! The file $tmp_wpcache_filename was empty. Did not rename to {$blog_cache_dir}{$cache_filename}", 5 );
+				wp_cache_debug( "Warning! The file $tmp_wpcache_filename was empty. Did not rename to {$dir}/{$cache_filename}", 5 );
 				@unlink( $tmp_wpcache_filename );
 			} else {
-				if ( !@rename( $tmp_wpcache_filename, $blog_cache_dir . $cache_filename ) ) {
-					if ( false == is_dir( $blog_cache_dir ) )
-						@wp_mkdir_p( $blog_cache_dir );
-					@unlink( $blog_cache_dir . $cache_filename );
-					@rename( $tmp_wpcache_filename, $blog_cache_dir . $cache_filename );
+				if ( !@rename( $tmp_wpcache_filename, $dir . '/' . $cache_filename ) ) {
+					if ( false == is_dir( $dir ) )
+						@wp_mkdir_p( $dir );
+					@unlink( $dir . $cache_filename );
+					@rename( $tmp_wpcache_filename, $dir . '/' . $cache_filename );
 				}
-				wp_cache_debug( "Renamed temp wp-cache file to {$blog_cache_dir}$cache_filename", 5 );
+				wp_cache_debug( "Renamed temp wp-cache file to {$dir}/$cache_filename", 5 );
 				$added_cache = 1;
 			}
 		}
@@ -930,24 +930,26 @@ function wp_cache_shutdown_callback() {
 		}
 
 		$serial = '<?php die(); ?>' . json_encode( $wp_cache_meta );
+		$dir = get_current_url_supercache_dir() . "meta/";
+		if( @is_dir( $dir ) == false )
+			@wp_mkdir_p( $dir );
+
 		if( wp_cache_writers_entry() ) {
-			wp_cache_debug( "Writing meta file: {$blog_cache_dir}meta/{$meta_file}", 2 );
+			wp_cache_debug( "Writing meta file: {$dir}{$meta_file}", 2 );
 			if ( false == $wp_cache_object_cache ) {
-				$tmp_meta_filename = $blog_cache_dir . 'meta/' . uniqid( mt_rand(), true ) . '.tmp';
-				$fr = @fopen( $tmp_meta_filename, 'w');
-				if( !$fr )
-					@wp_mkdir_p( $blog_cache_dir . 'meta' );
+				$tmp_meta_filename = $dir . uniqid( mt_rand(), true ) . '.tmp';
+				$final_meta_filename = $dir . $meta_file;
 				$fr = @fopen( $tmp_meta_filename, 'w');
 				if ( $fr ) {
 					fputs($fr, $serial);
 					fclose($fr);
 					@chmod( $tmp_meta_filename, 0666 & ~umask());
-					if( !@rename( $tmp_meta_filename, $blog_cache_dir . 'meta/' . $meta_file ) ) {
-						@unlink( $blog_cache_dir . 'meta/' . $meta_file );
-						@rename( $tmp_meta_filename, $blog_cache_dir . 'meta/' . $meta_file );
+					if( !@rename( $tmp_meta_filename, $final_meta_filename ) ) {
+						@unlink( $dir . $final_meta_filename );
+						@rename( $tmp_meta_filename, $final_meta_filename );
 					}
 				} else {
-					wp_cache_debug( "Problem writing meta file: {$blog_cache_dir}meta/{$meta_file}", 2 );
+					wp_cache_debug( "Problem writing meta file: {$final_meta_filename}" );
 				}
 			} elseif ( $cache_enabled ) {
 				$oc_key = get_oc_key() . ".meta";


### PR DESCRIPTION
If we store the legacy cache files in the supercache directory it will
be much easier to maintain them as they'll be in a directory structure
that reflects the URLs served by the site, just like supercache files.
This patch checks the original blogs_cache directory first but any new
cache files will be created in the supercache directory.