### PR TITLE
Check if headers are empty and then flush and get the headers again

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -122,6 +122,10 @@ if ( !function_exists( 'wp_cache_user_agent_is_rejected' ) ) {
 function wp_cache_get_response_headers() {
 	if(function_exists('apache_response_headers')) {
 		$headers = apache_response_headers();
+		if ( empty( $headers ) ) {
+			flush();
+			$headers = apache_response_headers();
+		}
 	} else if(function_exists('headers_list')) {
 		$headers = array();
 		foreach(headers_list() as $hdr) {


### PR DESCRIPTION
In #127 flush() was removed but a comment on apache_response_headers()
said that function may return an empty array, so I check for that here
and do a flush() before getting the headers again.