### PR TITLE
Add this filter for mobile detection

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -73,6 +73,9 @@ if ($cache_compression) {
 }
 
 add_cacheaction( 'supercache_filename_str', 'wp_cache_check_mobile' );
+if ( function_exists( 'add_filter' ) ) { // loaded since WordPress 4.6
+	add_filter( 'supercache_filename_str', 'wp_cache_check_mobile' );
+}
 
 $wp_cache_request_uri = $_SERVER[ 'REQUEST_URI' ]; // Cache this in case any plugin modifies it.
 


### PR DESCRIPTION
Fixes #184.
Since WordPress 4.6 plugin.php has been loaded before advanced-cache.php
which means that apply_filters and add_filter are available to caching
plugins. This patch adds the mobile UA check using add_filter.