### PR TITLE
Only define this rebuild directory if files are rebuilt.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -79,7 +79,6 @@ function wpcache_do_rebuild( $dir ) {
 	$dir = trailingslashit( $dir );
 	if ( isset( $do_rebuild_list[ $dir ] ) )
 		return false;
-	$do_rebuild_list[ $dir ] = 1;
 	$files_to_check = get_all_supercache_filenames( $dir );
 	foreach( $files_to_check as $cache_file ) {
 		$cache_file = $dir . $cache_file;
@@ -89,6 +88,7 @@ function wpcache_do_rebuild( $dir ) {
 		if( $mtime && (time() - $mtime) < 10 ) {
 			wp_cache_debug( "Rebuild file renamed to cache file temporarily: $cache_file", 3 );
 			@rename( $cache_file . '.needs-rebuild', $cache_file );
+			$do_rebuild_list[ $dir ] = 1;
 		}
 		// cleanup old files or if rename fails
 		if( @file_exists( $cache_file . '.needs-rebuild' ) ) {


### PR DESCRIPTION
The plugin was deleting cache files too often because it thought that
they were rebuilt files. This patch waits until files are rebuilt to
define that rebuild list.