### PR TITLE
Apply realpath to $cache_path to avoid problems on Windows

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -721,10 +721,10 @@ function wp_cache_confirm_delete( $dir ) {
 	// don't allow cache_path, blog cache dir, blog meta dir, supercache.
 	$dir = realpath( $dir );
 	if ( 
-		$dir == $cache_path || 
-		$dir == $blog_cache_dir ||
-		$dir == $blog_cache_dir . "meta/" ||
-		$dir == $cache_path . "supercache"
+		$dir == realpath( $cache_path ) ||
+		$dir == realpath( $blog_cache_dir ) ||
+		$dir == realpath( $blog_cache_dir . "meta/" ) ||
+		$dir == realpath( $cache_path . "supercache" )
 	) {
 		return false;
 	} else {

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -619,7 +619,8 @@ function get_all_supercache_filenames( $dir = '' ) {
 	global $wp_cache_mobile_enabled, $cache_path;
 
 	$dir = realpath( $dir );
-	if ( substr( $dir, 0, strlen( $cache_path ) ) != $cache_path )
+	$rp_cache_path = realpath( $cache_path );
+	if ( substr( $dir, 0, strlen( $rpcache_path ) ) != $rp_cache_path )
 		return array();
 
 	$filenames = array( 'index.html', 'index-https.html', 'index.html.php' );

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -620,7 +620,7 @@ function get_all_supercache_filenames( $dir = '' ) {
 
 	$dir = realpath( $dir );
 	$rp_cache_path = realpath( $cache_path );
-	if ( substr( $dir, 0, strlen( $rpcache_path ) ) != $rp_cache_path )
+	if ( substr( $dir, 0, strlen( $rp_cache_path ) ) != $rp_cache_path )
 		return array();
 
 	$filenames = array( 'index.html', 'index-https.html', 'index.html.php' );


### PR DESCRIPTION
Fixes #183.
realpath() on Windows will change a UNIX style path to a Windows C:\
type path.