### PR TITLE
If HTTP_HOST is not defined then disable caching.

### DIFF
--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -1,7 +1,12 @@
 <?php
 $known_headers = array("Last-Modified", "Expires", "Content-Type", "Content-type", "X-Pingback", "ETag", "Cache-Control", "Pragma");
 
-$WPSC_HTTP_HOST = htmlentities( $_SERVER[ 'HTTP_HOST' ] );
+if ( false == isset( $_SERVER[ 'HTTP_HOST' ] ) ) {
+	$cache_enabled = false;
+	$WPSC_HTTP_HOST = '';
+} else {
+	$WPSC_HTTP_HOST = htmlentities( $_SERVER[ 'HTTP_HOST' ] );
+}
 
 // We want to be able to identify each blog in a WordPress MU install
 $blogcacheid = '';


### PR DESCRIPTION
The HTTP_HOST is part of the cache key so it doesn't make sense to cache
the request. Also avoids a PHP notice.
https://wordpress.org/support/topic/php-notice-undefined-index-http_host-from-wp-cli/