### PR TITLE
realpath doesn't like array_walk and add file checks to rebuild

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -645,8 +645,10 @@ function wpsc_delete_files( $dir, $delete = true ) {
 
 	// only do this once, this function will be called many times
 	if ( $rp_cache_path == '' ) {
-		$protected = array( $cache_path, $cache_path . $blog_cache_dir, get_supercache_dir() );
-		$protected = array_walk( array_walk( $protected, 'realpath' ), 'trailingslashit' );
+		$protected = array( $cache_path, $cache_path . "blogs/", get_supercache_dir() );
+		foreach( $protected as $id => $directory ) {
+			$protected[ $id ] = trailingslashit( realpath( $directory ) );
+		}
 		$rp_cache_path = trailingslashit( realpath( $cache_path ) );
 	}
 

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -639,7 +639,7 @@ function wpsc_rebuild_files( $dir ) {
 }
 
 function wpsc_delete_files( $dir, $delete = true ) {
-	global $cache_path, $blog_cache_dir;
+	global $cache_path;
 	static $rp_cache_path = '';
 	static $protected = '';
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -75,7 +75,7 @@ function wp_cache_phase2() {
 }
 
 function wpcache_do_rebuild( $dir ) {
-	global $do_rebuild_list, $cache_path, $blog_cache_dir;
+	global $do_rebuild_list, $cache_path;
 
 	$dir = trailingslashit( realpath( $dir ) );
 	$protected = array( $cache_path, $cache_path . "blogs/", get_supercache_dir() );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -78,6 +78,10 @@ function wpcache_do_rebuild( $dir ) {
 	global $do_rebuild_list, $cache_path;
 
 	$dir = trailingslashit( realpath( $dir ) );
+
+	if ( isset( $do_rebuild_list[ $dir ] ) )
+		return false;
+
 	$protected = array( $cache_path, $cache_path . "blogs/", get_supercache_dir() );
 	foreach( $protected as $id => $directory ) {
 		$protected[ $id ] = trailingslashit( realpath( $directory ) );
@@ -88,9 +92,6 @@ function wpcache_do_rebuild( $dir ) {
 		return false;
 
 	if ( in_array( $dir, $protected ) )
-		return false;
-
-	if ( isset( $do_rebuild_list[ $dir ] ) )
 		return false;
 
 	if ( is_dir( $dir ) && $dh = @opendir( $dir ) ) {


### PR DESCRIPTION
realpath complained when using it in array_walk so go back to a simple
foreach loop.
The rebuild or gc function didn't have much checking to make sure it
wasn't deleting files it shouldn't be so this adds more, because I'm
paranoid.