### PR TITLE
Fixing error when using Preload Cron with WP-Cli

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3160,6 +3160,12 @@ function wp_cron_preload_cache() {
 		wp_cache_debug( "wp_cron_preload_cache: preload cancelled", 1 );
 		return true;
 	}
+
+	if ( !function_exists( 'wp_cache_debug' ) )
+		include_once( 'wp-cache-phase1.php' );
+	if ( !function_exists( 'prune_super_cache' ) )
+		include_once( 'wp-cache-phase2.php' );
+
 	$mutex = $cache_path . "preload_mutex.tmp";
 	sleep( 3 + mt_rand( 1, 5 ) );
 	if ( @file_exists( $mutex ) ) {


### PR DESCRIPTION
When using WP-Cli to run the event "wp_cache_full_preload_hook" causes the follow error

> /webdir/bin/wp cron event run --due-now

```
PHP Fatal error:  Uncaught Error: Call to undefined function wp_cache_debug() in /webdir/web/app/plugins/wp-super-cache/wp-cache.php:3163
Stack trace:
#0 /webdir/web/wp/wp-includes/class-wp-hook.php(298): wp_cron_preload_cache()
#1 /webdir/web/wp/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters('', Array)
#2 /webdir/web/wp/wp-includes/plugin.php(515): WP_Hook->do_action(Array)
#3 phar:///webdir/bin/wp/php/commands/cron-event.php(284): do_action_ref_array('wp_cache_full_p...', Array)
#4 phar:///webdir/bin/wp/php/commands/cron-event.php(255): Cron_Event_Command::run_event(Object(stdClass))
#5 [internal function]: Cron_Event_Command->run(Array, Array)
#6 phar:///webdir/bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php(67): call_user_func(Array, Array, Array)
#7 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#8 phar:///webdir/bin/wp/php/WP_CLI/Dispatcher/Subcommand.php(372): call_user_func(Objec in /webdir/web/app/plugins/wp-super-cache/wp-cache.php on line 3163
Fatal error: Uncaught Error: Call to undefined function wp_cache_debug() in /webdir/web/app/plugins/wp-super-cache/wp-cache.php:3163
Stack trace:
#0 /webdir/web/wp/wp-includes/class-wp-hook.php(298): wp_cron_preload_cache()
#1 /webdir/web/wp/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters('', Array)
#2 /webdir/web/wp/wp-includes/plugin.php(515): WP_Hook->do_action(Array)
#3 phar:///webdir/bin/wp/php/commands/cron-event.php(284): do_action_ref_array('wp_cache_full_p...', Array)
#4 phar:///webdir/bin/wp/php/commands/cron-event.php(255): Cron_Event_Command::run_event(Object(stdClass))
#5 [internal function]: Cron_Event_Command->run(Array, Array)
#6 phar:///webdir/bin/wp/php/WP_CLI/Dispatcher/CommandFactory.php(67): call_user_func(Array, Array, Array)
#7 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#8 phar:///webdir/bin/wp/php/WP_CLI/Dispatcher/Subcommand.php(372): call_user_func(Objec in /webdir/web/app/plugins/wp-super-cache/wp-cache.php on line 3163
```

This patch correct this based on deactivate/uninstall hooks which works on WP-Cli.