### PR TITLE
Hide warning when wp-cache-config.php doesn't exist and we include it.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -4,7 +4,7 @@
 if( !defined('WP_CONTENT_DIR') )
 	define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
 
-if( !include( WP_CONTENT_DIR . '/wp-cache-config.php' ) )
+if( !@include( WP_CONTENT_DIR . '/wp-cache-config.php' ) )
 	return false;
 
 if( !defined( 'WPCACHEHOME' ) )


### PR DESCRIPTION
When the plugin is first installed it tries to load wp-cache-config.php
but that file doesn't yet exist so a warning will show if the user has
display errors on. Let's just supress that.