### PR TITLE
Cache this to save on calls to realpath()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -757,7 +757,9 @@ function prune_super_cache( $directory, $force = false, $rename = false ) {
 	static $log = 0;
 	static $rp_cache_path = '';
 
-	$rp_cache_path = trailingslashit( realpath( $cache_path ) );
+	if ( $rp_cache_path == '' ) {
+		$rp_cache_path = trailingslashit( realpath( $cache_path ) );
+	}
 
 	$directory = trailingslashit( realpath( $directory ) );
 	if ( substr( $directory, 0, strlen( $rp_cache_path ) ) != $rp_cache_path ) {


### PR DESCRIPTION
prune_super_cache() can be called many times in one process so we should
make it run as fast as possible.