### PR TITLE
Don't add a trailing slash because it might be a file

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -653,7 +653,7 @@ function wpsc_delete_files( $dir, $delete = true ) {
 
 	// only do this once, this function will be called many times
 	if ( $rp_cache_path == '' ) {
-		$protected = array( $cache_path, $cache_path . "blogs/", get_supercache_dir() );
+		$protected = array( $cache_path, $cache_path . "blogs/", $cache_path . 'supercache' );
 		foreach( $protected as $id => $directory ) {
 			$protected[ $id ] = trailingslashit( realpath( $directory ) );
 		}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -890,7 +890,7 @@ function prune_super_cache( $directory, $force = false, $rename = false ) {
 }
 
 function wp_cache_rebuild_or_delete( $file ) {
-	global $cache_rebuild_files, $cache_path;
+	global $cache_rebuild_files, $cache_path, $file_prefix;
 	static $rp_cache_path = '';
 
 	if ( $rp_cache_path == '' ) {
@@ -916,6 +916,18 @@ function wp_cache_rebuild_or_delete( $file ) {
 
 	if ( in_array( $file, $protected ) ) {
 		wp_cache_debug( "rebuild_or_gc: file is protected: $file" );
+		return false;
+	}
+
+	if ( substr( basename( $file ), 0, mb_strlen( $file_prefix ) ) == $file_prefix ) {
+		@unlink( $file );
+		wp_cache_debug( "rebuild_or_gc: deleted non-anonymous file: $file" );
+		return false;
+	}
+
+	if ( substr( basename( $file ), 0, 5 + mb_strlen( $file_prefix ) ) == 'meta-' . $file_prefix ) {
+		@unlink( $file );
+		wp_cache_debug( "rebuild_or_gc: deleted meta file: $file" );
 		return false;
 	}
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -76,11 +76,14 @@ function wp_cache_phase2() {
 
 function wpcache_do_rebuild( $dir ) {
 	global $do_rebuild_list, $cache_path;
+	wp_cache_debug( "wpcache_do_rebuild: doing rebuild for $dir" );
 
 	$dir = trailingslashit( realpath( $dir ) );
 
-	if ( isset( $do_rebuild_list[ $dir ] ) )
+	if ( isset( $do_rebuild_list[ $dir ] ) ) {
+		wp_cache_debug( "wpcache_do_rebuild: directory already rebuilt: $dir" );
 		return false;
+	}
 
 	$protected = array( $cache_path, $cache_path . "blogs/", $cache_path . 'supercache' );
 	foreach( $protected as $id => $directory ) {
@@ -88,11 +91,15 @@ function wpcache_do_rebuild( $dir ) {
 	}
 	$rp_cache_path = trailingslashit( realpath( $cache_path ) );
 
-	if ( substr( $dir, 0, strlen( $rp_cache_path ) ) != $rp_cache_path )
+	if ( substr( $dir, 0, strlen( $rp_cache_path ) ) != $rp_cache_path ) {
+		wp_cache_debug( "wpcache_do_rebuild: exiting as directory not in cache_path: $dir" );
 		return false;
+	}
 
-	if ( in_array( $dir, $protected ) )
+	if ( in_array( $dir, $protected ) ) {
+		wp_cache_debug( "wpcache_do_rebuild: exiting as directory is protected: $dir" );
 		return false;
+	}
 
 	if ( is_dir( $dir ) && $dh = @opendir( $dir ) ) {
 		while ( ( $file = readdir( $dh ) ) !== false ) {
@@ -877,9 +884,15 @@ function wp_cache_rebuild_or_delete( $file ) {
 		}
 	}
 
-	if ( in_array( $file, $protected ) )
+	if ( in_array( $file, $protected ) ) {
+		wp_cache_debug( "rebuild_or_gc: file is protected: $file" );
 		return false;
+	}
 
+	if ( false == @file_exists( $file ) ) {
+		wp_cache_debug( "rebuild_or_gc: file has disappeared: $file" );
+		return false;
+	}
 	if( $cache_rebuild_files && substr( $file, -14 ) != '.needs-rebuild' ) {
 		if( @rename($file, $file . '.needs-rebuild') ) {
 			@touch( $file . '.needs-rebuild' );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -130,7 +130,7 @@ function wpcache_do_rebuild( $dir ) {
 
 		wp_cache_debug( "wpcache_do_rebuild: found rebuild file: $cache_file" );
 
-		if ( @file_exists( substr( $cache_file, 0, -14 ) ) ) { // index.html doesn't exist?
+		if ( @file_exists( substr( $cache_file, 0, -14 ) ) ) {
 			wp_cache_debug( "wpcache_do_rebuild: rebuild file deleted because base file found: $cache_file" );
 			@unlink( $cache_file ); // delete the rebuild file because index.html already exists
 			continue;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -761,9 +761,14 @@ function prune_super_cache( $directory, $force = false, $rename = false ) {
 		$rp_cache_path = trailingslashit( realpath( $cache_path ) );
 	}
 
-	$directory = trailingslashit( realpath( $directory ) );
+	$dir = $directory;
+	$directory = realpath( $directory );
+	if ( $directory == '' ) {
+		wp_cache_debug( "prune_super_cache: exiting as file/directory does not exist : $dir" );
+		return false;
+	}
 	if ( substr( $directory, 0, strlen( $rp_cache_path ) ) != $rp_cache_path ) {
-		wp_cache_debug( "prune_super_cache: exiting as directory is not in cache path: $directory" );
+		wp_cache_debug( "prune_super_cache: exiting as directory is not in cache path: *$directory* (was $dir before realpath)" );
 		return false;
 	}
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -82,7 +82,7 @@ function wpcache_do_rebuild( $dir ) {
 	if ( isset( $do_rebuild_list[ $dir ] ) )
 		return false;
 
-	$protected = array( $cache_path, $cache_path . "blogs/", get_supercache_dir() );
+	$protected = array( $cache_path, $cache_path . "blogs/", $cache_path . 'supercache' );
 	foreach( $protected as $id => $directory ) {
 		$protected[ $id ] = trailingslashit( realpath( $directory ) );
 	}
@@ -871,7 +871,7 @@ function wp_cache_rebuild_or_delete( $file ) {
 	}
 
 	if ( $protected == '' ) {
-		$protected = array( $cache_path . "index.html", get_supercache_dir() . "index.html", $cache_path . "blogs/index.html" );
+		$protected = array( $cache_path . "index.html", $cache_path . "supercache/index.html", $cache_path . "blogs/index.html" );
 		foreach( $protected as $id => $directory ) {
 			$protected[ $id ] = trailingslashit( realpath( $directory ) );
 		}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -941,11 +941,14 @@ function wp_cache_rebuild_or_delete( $file ) {
 			wp_cache_debug( "rebuild_or_gc: rename file to {$file}.needs-rebuild", 2 );
 		} else {
 			@unlink( $file );
-			wp_cache_debug( "rebuild_or_gc: deleted $file", 2 );
+			wp_cache_debug( "rebuild_or_gc: rename failed. deleted $file", 2 );
 		}
 	} else {
-		@unlink( $file );
-		wp_cache_debug( "rebuild_or_gc: deleted $file", 2 );
+		$mtime = @filemtime( $file );
+		if ( $mtime && ( time() - $mtime ) > 10 ) {
+			@unlink( $file );
+			wp_cache_debug( "rebuild_or_gc: rebuild file found. deleted because it was too old: $file", 2 );
+		}
 	}
 }
 


### PR DESCRIPTION
prune_super_cache() can delete files as well as directories so adding a
trailing slash stopped it deleting files.
Also added another warning if realpath() deleted the path given because
the item was not found.