### PR TITLE
The direct page caching feature is broken on https sites

### DIFF
--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -528,6 +528,32 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 
 
 	/**
+	 * set the cached direct pages list.
+	 */
+	protected function set_cache_direct_pages( $list ) {
+		if ( is_array( $list ) == false ) {
+			return false;
+		}
+
+		$_POST[ 'direct_pages' ] = $list;
+		wpsc_update_direct_pages();
+	}
+
+	/**
+	 * add an entry to the cached direct pages list.
+	 */
+	protected function new_direct_page( $value ) {
+		global $cached_direct_pages;
+
+		if ( isset( $_POST[ 'direct_pages' ] ) == false ) {
+			$_POST[ 'direct_pages' ] = $cached_direct_pages;
+		}
+
+		$_POST[ 'new_direct_page' ] = $value;
+		wpsc_update_direct_pages();
+	}
+
+	/**
 	 * Runs at the end and saves the preload settings.
 	 */
 	protected function save_preload_settings() {

--- a/rest/class.wp-super-cache-settings-map.php
+++ b/rest/class.wp-super-cache-settings-map.php
@@ -187,6 +187,10 @@ class WP_Super_Cache_Settings_Map {
 		),
 		'cache_direct_pages' => array(
 			'global' => 'cached_direct_pages',
+			'set'    => 'set_cache_direct_pages',
+		),
+		'new_direct_page' => array(
+			'set' => 'new_direct_page',
 		),
 		'ossdl_cname' => array(
 			'option' => 'ossdl_cname',

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -719,6 +719,8 @@ function get_all_supercache_filenames( $dir = '' ) {
 }
 
 function supercache_filename() {
+	global $cached_direct_pages;
+
 	//Add support for https and http caching
 	$is_https = ( ( isset( $_SERVER[ 'HTTPS' ] ) && 'on' ==  strtolower( $_SERVER[ 'HTTPS' ] ) ) || ( isset( $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ) && 'https' == strtolower( $_SERVER[ 'HTTP_X_FORWARDED_PROTO' ] ) ) ); //Also supports https requests coming from an nginx reverse proxy
 	$extra_str = $is_https ? '-https' : '';
@@ -727,6 +729,10 @@ function supercache_filename() {
 		$extra_str = apply_filters( 'supercache_filename_str', $extra_str );
 	} else {
 		$extra_str = do_cacheaction( 'supercache_filename_str', $extra_str );
+	}
+
+	if ( is_array( $cached_direct_pages ) && in_array( $_SERVER[ 'REQUEST_URI' ], $cached_direct_pages ) ) {
+		$extra_str = '';
 	}
 	$filename = 'index' . $extra_str . '.html';
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1432,6 +1432,75 @@ function wp_update_lock_down() {
 		return 0;
 }
 
+function wpsc_update_direct_pages() {
+	global $cached_direct_pages, $valid_nonce, $cache_path, $wp_cache_config_file;
+	$out = '';
+	if ( $valid_nonce && array_key_exists('direct_pages', $_POST) && is_array( $_POST[ 'direct_pages' ] ) && !empty( $_POST[ 'direct_pages' ] ) ) {
+		$expiredfiles = array_diff( $cached_direct_pages, $_POST[ 'direct_pages' ] );
+		unset( $cached_direct_pages );
+		foreach( $_POST[ 'direct_pages' ] as $page ) {
+			$page = str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $page ) );
+			if ( $page != '' ) {
+				$cached_direct_pages[] = $page;
+				$out .= "'$page', ";
+			}
+		}
+		if ( $out == '' ) {
+			$out = "'', ";
+		}
+	}
+	if ( $valid_nonce && array_key_exists('new_direct_page', $_POST) && $_POST[ 'new_direct_page' ] && '' != $_POST[ 'new_direct_page' ] ) {
+		$page = str_replace( get_option( 'siteurl' ), '', $_POST[ 'new_direct_page' ] );
+		$page = str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $page ) );
+		if( substr( $page, 0, 1 ) != '/' )
+			$page = '/' . $page;
+		if ( false == is_array( $cached_direct_pages ) || in_array( $page, $cached_direct_pages ) == false ) {
+			$cached_direct_pages[] = $page;
+			$out .= "'$page', ";
+		}
+	}
+
+	if ( $out != '' ) {
+		$out = substr( $out, 0, -2 );
+		$out = '$cached_direct_pages = array( ' . $out . ' );';
+		wp_cache_replace_line('^ *\$cached_direct_pages', "$out", $wp_cache_config_file);
+	}
+
+	if ( !empty( $expiredfiles ) ) {
+		foreach( $expiredfiles as $file ) {
+			if( $file != '' ) {
+				$firstfolder = explode( '/', $file );
+				$firstfolder = ABSPATH . $firstfolder[1];
+				$file = ABSPATH . $file;
+				$file = realpath( str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $file ) ) );
+				if ( $file ) {
+					@unlink( trailingslashit( $file ) . "index.html" );
+					@unlink( trailingslashit( $file ) . "index.html.gz" );
+					RecursiveFolderDelete( trailingslashit( $firstfolder ) );
+				}
+			}
+		}
+	}
+
+	if ( $valid_nonce && array_key_exists('deletepage', $_POST) && $_POST[ 'deletepage' ] ) {
+		$page = str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $_POST['deletepage'] ) ) . '/';
+		$pagefile = realpath( ABSPATH . $page . 'index.html' );
+		if ( substr( $pagefile, 0, strlen( ABSPATH ) ) != ABSPATH || false == wp_cache_confirm_delete( ABSPATH . $page ) ) {
+			die( __( 'Cannot delete directory', 'wp-super-cache' ) );
+		}
+		$firstfolder = explode( '/', $page );
+		$firstfolder = ABSPATH . $firstfolder[1];
+		$page = ABSPATH . $page;
+		if( is_file( $pagefile ) && is_writeable_ACLSafe( $pagefile ) && is_writeable_ACLSafe( $firstfolder ) ) {
+			@unlink( $pagefile );
+			@unlink( $pagefile . '.gz' );
+			RecursiveFolderDelete( $firstfolder );
+		}
+	}
+
+	return $cached_direct_pages;
+}
+
 function wp_lock_down() {
 	global $wpdb, $cache_path, $wp_cache_config_file, $valid_nonce, $cached_direct_pages, $cache_enabled, $super_cache_enabled;
 
@@ -1465,69 +1534,9 @@ function wp_lock_down() {
 	<fieldset class="options">
 	<h3><?php _e( 'Directly Cached Files', 'wp-super-cache' ); ?></h3><?php
 
-	$out = '';
-	if( $valid_nonce && array_key_exists('direct_pages', $_POST) && is_array( $_POST[ 'direct_pages' ] ) && !empty( $_POST[ 'direct_pages' ] ) ) {
-		$expiredfiles = array_diff( $cached_direct_pages, $_POST[ 'direct_pages' ] );
-		unset( $cached_direct_pages );
-		foreach( $_POST[ 'direct_pages' ] as $page ) {
-			$page = esc_sql( $page );
-			if( $page != '' ) {
-				$cached_direct_pages[] = $page;
-				$out .= "'$page', ";
-			}
-		}
-		if( $out == '' ) {
-			$out = "'', ";
-		}
-	}
-	if( $valid_nonce && array_key_exists('new_direct_page', $_POST) && $_POST[ 'new_direct_page' ] && '' != $_POST[ 'new_direct_page' ] ) {
-		$page = str_replace( get_option( 'siteurl' ), '', $_POST[ 'new_direct_page' ] );
-		if( substr( $page, 0, 1 ) != '/' )
-			$page = '/' . $page;
-		$page = esc_sql( $page );
-		if ( false == is_array( $cached_direct_pages ) || in_array( $page, $cached_direct_pages ) == false ) {
-			$cached_direct_pages[] = $page;
-			$out .= "'$page', ";
-		}
-	}
-
-	if( $out != '' ) {
-		$out = substr( $out, 0, -2 );
-		$out = '$cached_direct_pages = array( ' . $out . ' );';
-		wp_cache_replace_line('^ *\$cached_direct_pages', "$out", $wp_cache_config_file);
-		prune_super_cache( $cache_path, true );
-	}
-
-	if( !empty( $expiredfiles ) ) {
-		foreach( $expiredfiles as $file ) {
-			if( $file != '' ) {
-				$firstfolder = explode( '/', $file );
-				$firstfolder = ABSPATH . $firstfolder[1];
-				$file = ABSPATH . $file;
-				@unlink( trailingslashit( $file ) . 'index.html' );
-				@unlink( trailingslashit( $file ) . 'index.html.gz' );
-				RecursiveFolderDelete( trailingslashit( $firstfolder ) );
-			}
-		}
-	}
-
-	if( $valid_nonce && array_key_exists('deletepage', $_POST) && $_POST[ 'deletepage' ] ) {
-		$page = str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $_POST['deletepage'] ) ) . '/';
-		$pagefile = realpath( ABSPATH . $page . 'index.html' );
-		if ( substr( $pagefile, 0, strlen( ABSPATH ) ) != ABSPATH || false == wp_cache_confirm_delete( ABSPATH . $page ) ) {
-			die( __( 'Cannot delete directory', 'wp-super-cache' ) );
-		}
-		$firstfolder = explode( '/', $page );
-		$firstfolder = ABSPATH . $firstfolder[1];
-		$page = ABSPATH . $page;
-		if( is_file( $pagefile ) && is_writeable_ACLSafe( $pagefile ) && is_writeable_ACLSafe( $firstfolder ) ) {
-			@unlink( $pagefile );
-			@unlink( $pagefile . '.gz' );
-			RecursiveFolderDelete( $firstfolder );
-			echo "<strong>" . sprintf( __( '%s removed!', 'wp-super-cache' ), $pagefile ) . "</strong>";
-			prune_super_cache( $cache_path, true );
-		}
-	}
+	error_log( __LINE__ . " cached direct pages: " . print_r( $cached_direct_pages, 1 ) );
+	$cached_direct_pages = wpsc_update_direct_pages();
+	error_log( __LINE__ . " cached direct pages: " . print_r( $cached_direct_pages, 1 ) );
 
 	$readonly = '';
 	if( !is_writeable_ACLSafe( ABSPATH ) ) {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1537,9 +1537,7 @@ function wp_lock_down() {
 	<fieldset class="options">
 	<h3><?php _e( 'Directly Cached Files', 'wp-super-cache' ); ?></h3><?php
 
-	error_log( __LINE__ . " cached direct pages: " . print_r( $cached_direct_pages, 1 ) );
 	$cached_direct_pages = wpsc_update_direct_pages();
-	error_log( __LINE__ . " cached direct pages: " . print_r( $cached_direct_pages, 1 ) );
 
 	$readonly = '';
 	if( !is_writeable_ACLSafe( ABSPATH ) ) {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1452,11 +1452,14 @@ function wpsc_update_direct_pages() {
 	if ( $valid_nonce && array_key_exists('new_direct_page', $_POST) && $_POST[ 'new_direct_page' ] && '' != $_POST[ 'new_direct_page' ] ) {
 		$page = str_replace( get_option( 'siteurl' ), '', $_POST[ 'new_direct_page' ] );
 		$page = str_replace( '..', '', preg_replace('/[ <>\'\"\r\n\t\(\)]/', '', $page ) );
-		if( substr( $page, 0, 1 ) != '/' )
+		if ( substr( $page, 0, 1 ) != '/' )
 			$page = '/' . $page;
-		if ( false == is_array( $cached_direct_pages ) || in_array( $page, $cached_direct_pages ) == false ) {
+		if ( $page != '/' || false == is_array( $cached_direct_pages ) || in_array( $page, $cached_direct_pages ) == false ) {
 			$cached_direct_pages[] = $page;
 			$out .= "'$page', ";
+
+			@unlink( trailingslashit( ABSPATH . $page ) . "index.html" );
+			wpsc_delete_files( get_supercache_dir() . $page );
 		}
 	}
 


### PR DESCRIPTION
It needs reorganisation to work on the REST API too. By forcing the
plugin to write index.html files to the directly cached url that file
will be served to users visiting that page.
more to come ..