### PR TITLE
Cast these to avoid PHP7.1 warnings. Props @emo321

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1415,7 +1415,7 @@ function wp_cache_post_change( $post_id ) {
 function wp_cache_microtime_diff($a, $b) {
 	list($a_dec, $a_sec) = explode(' ', $a);
 	list($b_dec, $b_sec) = explode(' ', $b);
-	return $b_sec - $a_sec + $b_dec - $a_dec;
+	return (float)$b_sec - (float)$a_sec + (float)$b_dec - (float)$a_dec;
 }
 
 function wp_cache_post_id() {


### PR DESCRIPTION
PHP 7.1 must complain about variable types in mathematical
operations I guess.