### PR TITLE
Add "default_cache_path" setting so client can show it

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -157,8 +157,18 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 		return 0;
 	}
 
+	/**
+	 * @return int
+	 */
 	protected function get_post_count() {
 		$posts_count = wp_count_posts();
 		return $posts_count->publish;
+	}
+
+	/**
+	 * @return string
+	 */
+	protected function get_default_cache_path() {
+		return WP_CONTENT_DIR . '/wp-cache/';
 	}
 }

--- a/rest/class.wp-super-cache-settings-map.php
+++ b/rest/class.wp-super-cache-settings-map.php
@@ -80,6 +80,9 @@ class WP_Super_Cache_Settings_Map {
 			'global' => 'cache_path',
 			'set'    => 'set_wp_cache_location',
 		),
+		'default_cache_path' => array(
+			'get' => 'get_default_cache_path',
+		),
 		'use_object_cache' => array(
 			'global' => 'wp_cache_object_cache',
 		),


### PR DESCRIPTION
The Cache location should show the default cache path as that's shown on
the wp-admin page.