### PR TITLE
If there are no notices, return an empty object as the response

### DIFF
--- a/rest/class.wp-super-cache-rest-get-notices.php
+++ b/rest/class.wp-super-cache-rest-get-notices.php
@@ -19,7 +19,7 @@ class WP_Super_Cache_Rest_Get_Notices extends WP_REST_Controller {
 		$this->add_php_mod_rewrite_notice( $notices );
 
 		if ( empty( $notices ) ) {
-			return "{}";
+			return rest_ensure_response( new stdclass() );
 		} else {
 			return rest_ensure_response( $notices );
 		}


### PR DESCRIPTION
Returning `"{}"` returns a string. Returning `new stdclass()` will return an empty object.