### PR TITLE
Update the .htaccess rules safely without bringing down the site

### DIFF
--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -216,9 +216,12 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 
 			if ( $value == 1 ) { // mod_rewrite
 				$wp_cache_mod_rewrite = 1;
+				add_mod_rewrite_rules();
 
 			} elseif( $value == 2 ) { // PHP
 				$wp_cache_mod_rewrite = 0;
+				remove_mod_rewrite_rules();
+
 			}
 
 			wp_cache_setting( 'wp_cache_mod_rewrite', $wp_cache_mod_rewrite );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3730,7 +3730,7 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 	$url = trailingslashit( get_bloginfo( 'url' ) );
 	$original_page = wp_remote_get( $url, array( 'timeout' => 60, 'blocking' => true ) );
 	if ( is_wp_error( $original_page ) ) {
-		$update_mod_rewrite_rules_error = "WordPress rules empty";
+		$update_mod_rewrite_rules_error = "Problem loading page";
 		return false;
 	}
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3706,6 +3706,7 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 	$update_mod_rewrite_rules_error = false;
 
 	if ( defined( "DO_NOT_UPDATE_HTACCESS" ) )
+		$update_mod_rewrite_rules_error = ".htaccess update disabled by admin: DO_NOT_UPDATE_HTACCESS defined";
 		return false;
 
 	if ( ! function_exists( 'get_home_path' ) ) {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1393,8 +1393,11 @@ function wsc_mod_rewrite() {
 		echo '</div>';
 	}
 	// http://allmybrain.com/2007/11/08/making-wp-super-cache-gzip-compression-work/
-	$gziprules = insert_with_markers( $cache_path . '.htaccess', 'supercache', explode( "\n", $gziprules ) );
-	echo "<h4>" . sprintf( __( 'Gzip encoding rules in %s.htaccess created.', 'wp-super-cache' ), $cache_path ) . "</h4>";
+	$existing_gzip_rules = implode( "\n", extract_from_markers( $cache_path . '.htaccess', 'supercache' ) );
+	if ( $existing_gzip_rules != $gziprules ) {
+		$gziprules = insert_with_markers( $cache_path . '.htaccess', 'supercache', explode( "\n", $gziprules ) );
+		echo "<h4>" . sprintf( __( 'Gzip encoding rules in %s.htaccess created.', 'wp-super-cache' ), $cache_path ) . "</h4>";
+	}
 
 	?></fieldset><?php
 }

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1314,8 +1314,10 @@ function wsc_mod_rewrite() {
 		return false;
 	?>
 	<a name="modrewrite"></a><fieldset class="options">
-	<h3><?php _e( 'Mod Rewrite Rules', 'wp-super-cache' ); ?></h3><?php
+	<h3><?php _e( 'Mod Rewrite Rules', 'wp-super-cache' ); ?></h3>
+	<p><?php _e( 'When Expert cache delivery is enabled a file called <em>.htaccess</em> is modified. It should probably be in the same directory as your wp-config.php. This file has special rules that serve the cached files very quickly to visitors without ever executing PHP. The .htaccess file can be updated automatically, but if that fails, the rules will be displayed here and it can be edited by you. You will not need to update the rules unless a warning shows here.' ); ?></p>
 
+	<?php
 	extract( wpsc_get_htaccess_info() );
 	$dohtaccess = true;
 	global $wpmu_version;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3157,7 +3157,19 @@ function wpsc_get_htaccess_info() {
 	}
 	$home_path = get_home_path();
 	$home_root = parse_url(get_bloginfo('url'));
-	$home_root = isset( $home_root['path'] ) ? trailingslashit( $home_root['path'] ) : '/';
+	$home_root = isset( $home_root[ 'path' ] ) ? trailingslashit( $home_root[ 'path' ] ) : '/';
+	if (
+		$home_root == '/' &&
+		$home_path != $_SERVER[ 'DOCUMENT_ROOT' ]
+	) {
+		$home_path = $_SERVER[ 'DOCUMENT_ROOT' ];
+	} elseif (
+		$home_root != '/' &&
+		$home_path != str_replace( '//', '/', $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root ) &&
+		is_dir( $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root )
+	) {
+		$home_path = str_replace( '//', '/', $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root );
+	}
 	$home_root_lc = str_replace( '//', '/', strtolower( $home_root ) );
 	$inst_root = str_replace( '//', '/', '/' . trailingslashit( str_replace( $content_dir_root, '', str_replace( '\\', '/', WP_CONTENT_DIR ) ) ) );
 	$wprules = implode( "\n", extract_from_markers( $home_path.'.htaccess', 'WordPress' ) );
@@ -3714,6 +3726,20 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 		include_once( ABSPATH . 'wp-admin/includes/misc.php' ); // extract_from_markers()
 	}
 	$home_path = trailingslashit( get_home_path() );
+	$home_root = parse_url( get_bloginfo( 'url' ) );
+	$home_root = isset( $home_root[ 'path' ] ) ? trailingslashit( $home_root[ 'path' ] ) : '/';
+	if (
+		$home_root == '/' &&
+		$home_path != $_SERVER[ 'DOCUMENT_ROOT' ]
+	) {
+		$home_path = $_SERVER[ 'DOCUMENT_ROOT' ];
+	} elseif (
+		$home_root != '/' &&
+		$home_path != str_replace( '//', '/', $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root ) &&
+		is_dir( $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root )
+	) {
+		$home_path = str_replace( '//', '/', $_SERVER[ 'DOCUMENT_ROOT' ] . $home_root );
+	}
 
 	if ( ! file_exists( $home_path . ".htaccess" ) ) {
 		$update_mod_rewrite_rules_error = ".htaccess not found: {$home_path}.htaccess";

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1352,7 +1352,7 @@ function wsc_mod_rewrite() {
 		wpsc_update_htaccess_form();
 		echo "<div id='rewriterules' style='display: none;'>";
 		if ( $rules != $scrules )
-			echo '<div style="background: #fff; border: 1px solid #333; margin: 2px;">' . wp_text_diff( $scrules, $rules, array( 'title' => 'Rewrite Rules', 'title_left' => 'Current Rules', 'title_right' => 'New Rules' ) ) . "</div>";
+			echo '<div style="background: #fff; border: 1px solid #333; margin: 2px;">' . wp_text_diff( $scrules, $rules, array( 'title' => __( 'Rewrite Rules', 'wp-super-cache' ), 'title_left' => __( 'Current Rules', 'wp-super-cache' ), 'title_right' => __( 'New Rules', 'wp-super-cache' ) ) ) . "</div>";
 		echo "<p><pre># BEGIN WPSuperCache\n" . esc_html( $rules ) . "# END WPSuperCache</pre></p>\n";
 		echo "<p>" . sprintf( __( 'Rules must be added to %s too:', 'wp-super-cache' ), WP_CONTENT_DIR . "/cache/.htaccess" ) . "</p>";
 		echo "<pre># BEGIN supercache\n" . esc_html( $gziprules ) . "# END supercache</pre></p>";


### PR DESCRIPTION
mod_rewrite rules have to be updated to use Export mode but if done
incorrectly the site can be taken offline. This code makes a backup of
the .htaccess file, grabs a copy of the front page, updates the rules,
grabs the front page again and if they are not the same then it restores
the backup.
TODO: more error reporting as there are so many checks.