### PR TITLE
Split compression status into two to make it more granular.

### DIFF
--- a/rest/class.wp-super-cache-rest-get-status.php
+++ b/rest/class.wp-super-cache-rest-get-status.php
@@ -77,9 +77,9 @@ class WP_Super_Cache_Rest_Get_Status extends WP_REST_Controller {
 	 */
 	protected function add_compression_status( & $status ) {
 		if ( defined( 'WPSC_DISABLE_COMPRESSION' ) ) {
-			$status['compression_disabled'] = true;
+			$status['compression_disabled_by_admin'] = true;
 		} elseif ( false == function_exists( 'gzencode' ) ) {
-			$status['compression_disabled'] = true;
+			$status['compression_disabled_no_gzencode'] = true;
 		}
 	}
 


### PR DESCRIPTION
Following from
https://github.com/Automattic/wp-super-cache/pull/264/files#r123956625 I
split the compression_disabled status into compression_disabled_by_admin
and compression_disabled_no_gzencode.