### PR TITLE
Enable supercaching by default because it's now always enabled.

### DIFF
--- a/wp-cache-config-sample.php
+++ b/wp-cache-config-sample.php
@@ -10,7 +10,7 @@ if ( ! defined('WPCACHEHOME') )
 
 $cache_compression = 0; // Super cache compression
 $cache_enabled = false;
-$super_cache_enabled = false;
+$super_cache_enabled = true;
 $cache_max_time = 3600; //in seconds
 //$use_flock = true; // Set it true or false if you know what to use
 $cache_path = WP_CONTENT_DIR . '/cache/';


### PR DESCRIPTION
The new settings page doesn't have an option to disable supercaching, only simple/expert delivery methods so make sure it's enabled by default on new installs.