### PR TITLE
Preserve headers, don't delete them.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -189,8 +189,6 @@ function wp_cache_get_response_headers() {
 
 			$headers[$header_name] = $header_value;
 		}
-	} else {
-		$headers = null;
 	}
 
 	return $headers;


### PR DESCRIPTION
This was deleting the headers retrieved from apache_response_headers()
if headers_list existed. :(