### PR TITLE
Replace is_super_admin() >= WP 4.8

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -165,6 +165,12 @@ function wpsupercache_activate() {
 register_activation_hook( __FILE__, 'wpsupercache_activate' );
 
 function wpsupercache_site_admin() {
+	global $wp_version;
+
+	if ( version_compare( "4.8", $wp_version, "<=" ) ) {
+		return current_user_can( 'setup_network' );
+	}
+
 	if ( function_exists( 'is_super_admin' ) ) {
 		return is_super_admin();
 	} elseif ( function_exists( 'is_site_admin' ) ) {


### PR DESCRIPTION
Fixes #247
Using is_super_admin() is discouraged in WP 4.8 and later.