### PR TITLE
Return the debug log as URL rather than single filename

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -111,6 +111,14 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 	/**
 	 * @return bool
 	 */
+	protected function get_wp_cache_debug_log() {
+		global $cache_path, $wp_cache_debug_log;
+		return site_url( str_replace( ABSPATH, '', "{$cache_path}{$wp_cache_debug_log}" ) );
+	}
+
+	/**
+	 * @return bool
+	 */
 	protected function get_is_submit_enabled() {
 		global $wp_cache_config_file;
 		return is_writeable_ACLSafe( $wp_cache_config_file );

--- a/rest/class.wp-super-cache-settings-map.php
+++ b/rest/class.wp-super-cache-settings-map.php
@@ -226,7 +226,7 @@ class WP_Super_Cache_Settings_Map {
 			'global' => 'wp_cache_debug_username',
 		),
 		'wp_cache_debug_log' => array(
-			'global' => 'wp_cache_debug_log',
+			'get'    => 'get_wp_cache_debug_log',
 		),
 		'wp_cache_debug_ip' => array(
 			'global' => 'wp_cache_debug_ip',


### PR DESCRIPTION
The debug log is in $cache_path but since the URL to that directory is not exposed by the API we need to add it to the debug_log filename to be used.