### PR TITLE
Save arrays or objects to the config file with wp_cache_setting()

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2142,6 +2142,10 @@ function wp_cache_setting( $field, $value ) {
 	$$field = $value;
 	if ( is_numeric( $value ) ) {
 		wp_cache_replace_line( '^ *\$' . $field, "\$$field = $value;", $wp_cache_config_file );
+	} elseif ( is_object( $value ) || is_array( $value ) ) {
+		$text = var_export( $value, true );
+		$text = preg_replace( '/[\s]+/', ' ', $text );
+		wp_cache_replace_line( '^ *\$' . $field, "\$$field = $text;", $wp_cache_config_file );
 	} else {
 		wp_cache_replace_line( '^ *\$' . $field, "\$$field = '$value';", $wp_cache_config_file );
 	}


### PR DESCRIPTION
wp_cache_setting() supported saving integers or strings to the config file but arrays or objects would have to be serialised or converted to a string before saving. This modification uses var_export() to create PHP code to recreate the array or object .