### PR TITLE
Display log files on debug page and remove action buttons

### DIFF
--- a/rest/class.wp-super-cache-rest-debug.php
+++ b/rest/class.wp-super-cache-rest-debug.php
@@ -1,0 +1,41 @@
+<?php
+
+class WP_Super_Cache_Rest_Debug_List extends WP_REST_Controller {
+
+	/**
+	 * Return list of debug logs
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_list( $request ) {
+		$parameters = $request->get_json_params();
+
+		$list = wpsc_get_debug_log_list();
+
+		return rest_ensure_response( $list );
+	}
+
+	/**
+	 * Update list of debug logs
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_list( $request ) {
+		global $cache_path, $wp_cache_debug_log, $wp_cache_debug_username;
+
+		$parameters = $request->get_json_params();
+
+		$wp_cache_debug_list = wpsc_get_debug_log_list();
+		if ( isset( $wp_cache_debug_list[ $parameters[ 'filename' ] ] ) ) {
+			@unlink( $cache_path . $parameters[ 'filename' ] );
+			if ( $wp_cache_debug_log == $parameters[ 'filename' ] ) {
+				wpsc_create_debug_log( $wp_cache_debug_log, $wp_cache_debug_username );
+			}
+			$wp_cache_debug_list = wpsc_get_debug_log_list();
+		}
+
+		return rest_ensure_response( $wp_cache_debug_list );
+	}
+}

--- a/rest/load.php
+++ b/rest/load.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/class.wp-super-cache-rest-get-status.php';
 require_once __DIR__ . '/class.wp-super-cache-rest-test-cache.php';
 require_once __DIR__ . '/class.wp-super-cache-rest-delete-cache.php';
 require_once __DIR__ . '/class.wp-super-cache-rest-preload.php';
+require_once __DIR__ . '/class.wp-super-cache-rest-debug.php';
 
 class WP_Super_Cache_Router {
 
@@ -32,6 +33,7 @@ class WP_Super_Cache_Router {
 		$delete_cache 	 = new WP_Super_Cache_Rest_Delete_Cache();
 		$preload_cache   = new WP_Super_Cache_Rest_Preload();
 		$get_status 	 = new WP_Super_Cache_Rest_Get_Status();
+		$debug_lists     = new WP_Super_Cache_Rest_Debug_List();
 
 		register_rest_route( $namespace, '/settings', array(
 			array(
@@ -60,6 +62,20 @@ class WP_Super_Cache_Router {
 			'permission_callback' => __CLASS__ . '::get_item_permissions_check',
 		) );
 
+		register_rest_route( $namespace, '/debug', array(
+			array(
+				'methods'         	  => WP_REST_Server::READABLE,
+				'callback'        	  => array( $debug_lists, 'get_list' ),
+				'permission_callback' => __CLASS__ . '::get_item_permissions_check',
+				'args'            	  => array(),
+			),
+			array(
+				'methods'         	  => WP_REST_Server::DELETABLE,
+				'callback'        	  => array( $debug_lists, 'update_list' ),
+				'permission_callback' => __CLASS__ . '::delete_item_permissions_check',
+				'args'           	  => array(),
+			),
+		) );
 
 		register_rest_route( $namespace, '/cache', array(
 			array(


### PR DESCRIPTION
The debug page should display a list of debug logs used, both in the past and the current one.