### PR TITLE
Fix/cache more headers

### DIFF
--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -128,6 +128,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 			'cache_rebuild_files',
 			'wp_cache_refresh_single_only',
 			'wp_cache_mutex_disabled',
+			'wpsc_save_headers',
 		);
 
 		if ( ! in_array( $global_name, $whitelist ) ) {

--- a/rest/class.wp-super-cache-settings-map.php
+++ b/rest/class.wp-super-cache-settings-map.php
@@ -67,6 +67,9 @@ class WP_Super_Cache_Settings_Map {
 		'clear_cache_on_post_edit' => array(
 			'global' => 'wp_cache_clear_on_post_edit',
 		),
+		'wpsc_save_headers' => array(
+			'global' => 'wpsc_save_headers',
+		),
 		'cache_rebuild' => array(
 			'global' => 'cache_rebuild_files',
 		),

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -1,6 +1,4 @@
 <?php
-$known_headers = array("Last-Modified", "Expires", "Content-Type", "Content-type", "X-Pingback", "ETag", "Cache-Control", "Pragma");
-
 if ( false == isset( $_SERVER[ 'HTTP_HOST' ] ) ) {
 	$cache_enabled = false;
 	$WPSC_HTTP_HOST = '';

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -190,6 +190,7 @@ function wp_cache_serve_cache_file() {
 			return true;
 		}
 	} else { // no $cache_file
+		global $wpsc_save_headers;
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host
 		$filename = supercache_filename();
 		$file = get_current_url_supercache_dir() . $filename;
@@ -201,6 +202,9 @@ function wp_cache_serve_cache_file() {
 			return false;
 		} elseif ( wp_cache_get_cookies_values() != '' ) {
 			wp_cache_debug( "Cookies found. Cannot serve a supercache file. " . wp_cache_get_cookies_values() );
+			return false;
+		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
+			wp_cache_debug( "Saving headers. Cannot serve a supercache file." );
 			return false;
 		}
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -365,7 +365,7 @@ function wp_super_cache_query_vars() {
 }
 
 function wp_cache_ob_callback( $buffer ) {
-	global $wp_cache_pages, $wp_query, $wp_super_cache_query, $cache_acceptable_files, $wp_cache_no_cache_for_get, $wp_cache_object_cache, $wp_cache_request_uri, $do_rebuild_list, $wpsc_file_mtimes;
+	global $wp_cache_pages, $wp_query, $wp_super_cache_query, $cache_acceptable_files, $wp_cache_no_cache_for_get, $wp_cache_object_cache, $wp_cache_request_uri, $do_rebuild_list, $wpsc_file_mtimes, $wpsc_save_headers, $super_cache_enabled;
 	$buffer = apply_filters( 'wp_cache_ob_callback_filter', $buffer );
 
 	$script = basename($_SERVER['PHP_SELF']);
@@ -430,6 +430,9 @@ function wp_cache_ob_callback( $buffer ) {
 		wp_cache_debug( 'Not caching feed.', 2 );
 		$cache_this_page = false;
 	}
+
+	if ( isset( $wpsc_save_headers ) && $wpsc_save_headers )
+		$super_cache_enabled = false; // use standard caching to record headers
 
 	if ( !isset( $wp_query ) )
 		wp_cache_debug( 'wp_cache_ob_callback: WARNING! $query not defined but the plugin has worked around that problem.', 4 );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -225,6 +225,7 @@ function wp_cache_get_response_headers() {
 						'X-UA-Compatible',
 					);
 
+	$known_headers = apply_filters( 'wpsc_known_headers', $known_headers );
 
 	if ( ! isset( $known_headers[ 'age' ] ) ) {
 		$known_headers = array_map( 'mb_strtolower', $known_headers );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -176,6 +176,60 @@ if ( !function_exists( 'wp_cache_user_agent_is_rejected' ) ) {
 }
 
 function wp_cache_get_response_headers() {
+	static $known_headers = array(
+						'Access-Control-Allow-Origin',
+						'Accept-Ranges',
+						'Age',
+						'Allow',
+						'Cache-Control',
+						'Connection',
+						'Content-Encoding',
+						'Content-Language',
+						'Content-Length',
+						'Content-Location',
+						'Content-MD5',
+						'Content-Disposition',
+						'Content-Range',
+						'Content-Type',
+						'Date',
+						'ETag',
+						'Expires',
+						'Last-Modified',
+						'Link',
+						'Location',
+						'P3P',
+						'Pragma',
+						'Proxy-Authenticate',
+						"Referrer-Policy",
+						'Refresh',
+						'Retry-After',
+						'Server',
+						'Status',
+						'Strict-Transport-Security',
+						'Trailer',
+						'Transfer-Encoding',
+						'Upgrade',
+						'Vary',
+						'Via',
+						'Warning',
+						'WWW-Authenticate',
+						'X-Frame-Options',
+						'Public-Key-Pins',
+						'X-XSS-Protection',
+						'Content-Security-Policy',
+						"X-Pingback",
+						'X-Content-Security-Policy',
+						'X-WebKit-CSP',
+						'X-Content-Type-Options',
+						'X-Powered-By',
+						'X-UA-Compatible',
+					);
+
+
+	if ( ! isset( $known_headers[ 'age' ] ) ) {
+		$known_headers = array_map( 'mb_strtolower', $known_headers );
+	}
+
 	$headers = array();
 	if ( function_exists( 'apache_response_headers' ) ) {
 		$headers = apache_response_headers();
@@ -188,6 +242,12 @@ function wp_cache_get_response_headers() {
 			$header_value = isset( $header_parts[1] ) ? trim( $header_parts[1] ) : '';
 
 			$headers[$header_name] = $header_value;
+		}
+	}
+
+	foreach( $headers as $key => $value ) {
+		if ( ! in_array( mb_strtolower( $key ), $known_headers ) ) {
+			unset( $headers[ $key ] );
 		}
 	}
 
@@ -1015,11 +1075,9 @@ function wp_cache_shutdown_callback() {
 	$wp_cache_meta[ 'key' ] = $wp_cache_key;
 	$wp_cache_meta = apply_filters( 'wp_cache_meta', $wp_cache_meta );
 
-	$response = wp_cache_get_response_headers();
-	foreach ($known_headers as $key) {
-		if(isset($response[$key])) {
-			$wp_cache_meta[ 'headers' ][ $key ] = "$key: " . $response[$key];
-		}
+	$headers = wp_cache_get_response_headers();
+	foreach( $headers as $key => $value ) {
+		$wp_cache_meta[ 'headers' ][ $key ] = "$key: $value";
 	}
 
 	wp_cache_debug( "wp_cache_shutdown_callback: collecting meta data.", 2 );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -437,7 +437,7 @@ if ( isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] == 'delcachepage' )
 
 function wp_cache_manager_updates() {
 	global $wp_cache_mobile_enabled, $wp_cache_mfunc_enabled, $wp_supercache_cache_list, $wp_cache_config_file, $wp_cache_hello_world, $wp_cache_clear_on_post_edit, $cache_rebuild_files, $wp_cache_mutex_disabled, $wp_cache_not_logged_in, $wp_cache_make_known_anon, $cache_path, $wp_cache_object_cache, $_wp_using_ext_object_cache, $wp_cache_refresh_single_only, $cache_compression, $wp_cache_mod_rewrite, $wp_supercache_304, $wp_super_cache_late_init, $wp_cache_front_page_checks, $cache_page_secret, $wp_cache_disable_utf8, $wp_cache_no_cache_for_get;
-	global $cache_schedule_type, $cache_max_time, $cache_time_interval, $wp_cache_shutdown_gc;
+	global $cache_schedule_type, $cache_max_time, $cache_time_interval, $wp_cache_shutdown_gc, $wpsc_save_headers;
 
 	if ( !wpsupercache_site_admin() )
 		return false;
@@ -607,6 +607,13 @@ function wp_cache_manager_updates() {
 		}
 		wp_cache_replace_line('^ *\$cache_rebuild_files', "\$cache_rebuild_files = " . $cache_rebuild_files . ";", $wp_cache_config_file);
 
+		if ( isset( $_POST[ 'wpsc_save_headers' ] ) ) {
+			$wpsc_save_headers = 1;
+		} else {
+			$wpsc_save_headers = 0;
+		}
+		wp_cache_replace_line('^ *\$wpsc_save_headers', "\$wpsc_save_headers = " . $wpsc_save_headers . ";", $wp_cache_config_file);
+
 		if( isset( $_POST[ 'wp_cache_mutex_disabled' ] ) ) {
 			$wp_cache_mutex_disabled = 0;
 		} else {
@@ -683,7 +690,7 @@ function wp_cache_manager() {
 	global $wp_cache_not_logged_in, $wp_cache_make_known_anon, $wp_supercache_cache_list, $cache_page_secret;
 	global $wp_super_cache_front_page_check, $wp_cache_object_cache, $_wp_using_ext_object_cache, $wp_cache_refresh_single_only, $wp_cache_mobile_prefixes;
 	global $wp_cache_mod_rewrite, $wp_supercache_304, $wp_super_cache_late_init, $wp_cache_front_page_checks, $wp_cache_disable_utf8, $wp_cache_mfunc_enabled;
-	global $wp_super_cache_comments, $wp_cache_home_path;
+	global $wp_super_cache_comments, $wp_cache_home_path, $wpsc_save_headers;
 
 	if ( !wpsupercache_site_admin() )
 		return false;
@@ -981,6 +988,7 @@ table.wpsc-settings-table {
 					<?php }
 				}
 				?>
+				<label><input type='checkbox' name='wpsc_save_headers' <?php if ( $wpsc_save_headers ) echo "checked"; ?> value='1' /> <?php _e( 'Cache HTTP headers with page content.', 'wp-super-cache' ); ?></label><br />
 				<label><input type='checkbox' name='cache_rebuild_files' <?php if ( $cache_rebuild_files ) echo "checked"; ?> value='1'> <?php _e( 'Cache rebuild. Serve a supercache file to anonymous users while a new file is being generated.', 'wp-super-cache' ); echo " <em>(" . __( "Recommended", "wp-super-cache" ) . ")</em>"; ?></label><br />
 				<?php
 				$disable_304 = true;


### PR DESCRIPTION
Fixes #165 

We should be able to cache more headers. This list was taken from Comet Cache [here](https://github.com/websharks/comet-cache/blob/dev/src/includes/traits/Shared/HttpUtils.php#L67).
It includes two headers that this plugin already recognised, and also adds a filter called "wpsc_known_headers" for site owners to modify the list of headers.
