### PR TITLE
Use opcache_invalidate to load the updated config file

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -21,6 +21,10 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 				wp_cache_replace_line( '^.*WPLOCKDOWN', "if ( ! defined( 'WPLOCKDOWN' ) ) define( 'WPLOCKDOWN', " . $this->get_is_lock_down_enabled() . " );", $wp_cache_config_file );
 			}
 		}
+
+		if ( function_exists( "opcache_invalidate" ) ) {
+			opcache_invalidate( $wp_cache_config_file );
+		}
 		include( $wp_cache_config_file );
 
 		foreach ( WP_Super_Cache_Settings_Map::$map as $name => $map ) {
@@ -60,6 +64,9 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 	 */
 	public function get_cache_type() {
 		global $wp_cache_config_file;
+		if ( function_exists( "opcache_invalidate" ) ) {
+			opcache_invalidate( $wp_cache_config_file );
+		}
 		include( $wp_cache_config_file );
 
 		if ( $super_cache_enabled ) {
@@ -122,6 +129,9 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 	 */
 	protected function get_wp_cache_debug_log() {
 		global $wp_cache_config_file;
+		if ( function_exists( "opcache_invalidate" ) ) {
+			opcache_invalidate( $wp_cache_config_file );
+		}
 		include( $wp_cache_config_file );
 		return site_url( str_replace( ABSPATH, '', "{$cache_path}{$wp_cache_debug_log}" ) );
 	}

--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -608,6 +608,9 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 			$cache_page_secret = md5( date( 'H:i:s' ) . mt_rand() );
 			wp_cache_setting( 'cache_page_secret', $cache_page_secret );
 
+			if ( function_exists( "opcache_invalidate" ) ) {
+				opcache_invalidate( $wp_cache_config_file );
+			}
 		}
 		wpsc_set_default_gc( true );
 


### PR DESCRIPTION
While the config file may have been updated by PHP, any attempt to load
the file will load the version cached by PHP. opcache_invalidate() will
recompile the config file before loading it so changes are seen.