### PR TITLE
On preloading delete all files in post directories, not just index ones

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3286,11 +3286,8 @@ function clear_post_supercache( $post_id ) {
 	if ( !function_exists( 'prune_super_cache' ) )
 		include_once( 'wp-cache-phase2.php' );
 
-	wp_cache_debug( "clear_post_supercache: deleting $dir/index*.html files", 2 );
-	$files_to_check = get_all_supercache_filenames( $dir );
-	foreach( $files_to_check as $cache_file ) {
-		prune_super_cache( $dir . $cache_file, true );
-	}
+	wp_cache_debug( "clear_post_supercache: deleting files in $dir", 2 );
+	prune_super_cache( $dir, true );
 }
 
 function wp_cron_preload_cache() {


### PR DESCRIPTION
On preload the plugin deletes index files but now the standard caching files are in the same directories so we should delete them too.