### PR TITLE
Check if WP_REST_Controller exists before loading the REST API

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -63,7 +63,9 @@ if( !defined( 'WP_CACHE' ) || ( defined( 'WP_CACHE' ) && constant( 'WP_CACHE' ) 
 }
 
 include(WPCACHEHOME . 'wp-cache-base.php');
-include( WPCACHEHOME . 'rest/load.php' );
+if ( class_exists( 'WP_REST_Controller' ) ) {
+	include( WPCACHEHOME . 'rest/load.php' );
+}
 
 function wp_super_cache_text_domain() {
 	load_plugin_textdomain( 'wp-super-cache', false, basename( dirname( __FILE__ ) ) . '/languages' );


### PR DESCRIPTION
The WP_REST_Controller class doesn't exist before WordPress 4.7. There
are still sites that haven't upgraded to that version so avoid crashing
their sites.
Ref: https://wordpress.org/support/topic/site-inacessible-after-update/