### PR TITLE
Some sites use old versions of PHP that don't support anon functions.

### DIFF
--- a/rest/load.php
+++ b/rest/load.php
@@ -141,7 +141,9 @@ class WP_Super_Cache_Router {
 
 }
 
-add_action( 'rest_api_init', function() {
+function wpsc_load_rest_api() {
 	$wpsupercache_route = new WP_Super_Cache_Router;
 	$wpsupercache_route->register_routes();
-} );
+};
+
+add_action( 'rest_api_init', 'wpsc_load_rest_api' );


### PR DESCRIPTION
WordPress can run on PHP 5.2.4 so plugins should too.
ref: https://wordpress.org/support/topic/parse-error-syntax-error-unexpected-t_function-30/