### PR TITLE
Fix detection of mobile visitors when using WP-Cache caching.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -118,7 +118,7 @@ function get_wp_cache_key( $url = false ) {
 		$url = $wp_cache_request_uri;
 	}
 	$server_port = isset( $_SERVER[ 'SERVER_PORT' ] ) ? intval( $_SERVER[ 'SERVER_PORT' ] ) : 0;
-	return do_cacheaction( 'wp_cache_key', $WPSC_HTTP_HOST . $server_port . preg_replace('/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() );
+	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace('/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
 }
 
 function wp_super_cache_init() {


### PR DESCRIPTION
Fixes #300
The cache key used by WP-Cache caching for known users and other
non-anonymous users didn't contain the mobile status so the same file
would be served to mobile and desktop visitors.