### PR TITLE
"Served by" header is now optional, set by $wpsc_served_header.

### DIFF
--- a/wp-cache-config-sample.php
+++ b/wp-cache-config-sample.php
@@ -97,4 +97,5 @@ $wp_cache_preload_email_me = 0;
 $wp_cache_preload_email_volume = 'none';
 $wp_cache_mobile_prefixes = '';
 $cached_direct_pages = array();
+$wpsc_served_header = false;
 ?>

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -138,7 +138,7 @@ function wp_super_cache_init() {
 function wp_cache_serve_cache_file() {
 	global $key, $blogcacheid, $wp_cache_request_uri, $file_prefix, $blog_cache_dir, $meta_file, $cache_file, $cache_filename, $meta_pathname, $wp_cache_gzip_encoding, $meta;
 	global $wp_cache_object_cache, $cache_compression, $wp_cache_slash_check, $wp_supercache_304, $wp_cache_home_path, $wp_cache_no_cache_for_get;
-	global $wp_cache_disable_utf8, $wp_cache_mfunc_enabled;
+	global $wp_cache_disable_utf8, $wp_cache_mfunc_enabled, $wpsc_served_header;
 
 	if ( is_admin() ) {
 		wp_cache_debug( 'Not serving wp-admin requests.', 5 );
@@ -255,14 +255,20 @@ function wp_cache_serve_cache_file() {
 			header( "Cache-Control: max-age=3, must-revalidate" );
 			$size = function_exists( 'mb_strlen' ) ? mb_strlen( $cachefiledata, '8bit' ) : strlen( $cachefiledata );
 			if ( $wp_cache_gzip_encoding ) {
-				header( "WP-Super-Cache: Served supercache gzip file from PHP" );
+				if ( isset( $wpsc_served_header ) && $wpsc_served_header ) {
+					header( "X-WP-Super-Cache: Served supercache gzip file from PHP" );
+				}
 				header( 'Content-Encoding: ' . $wp_cache_gzip_encoding );
 				header( 'Content-Length: ' . $size );
 			} elseif ( $wp_supercache_304 ) {
-				header( "WP-Super-Cache: Served supercache 304 file from PHP" );
+				if ( isset( $wpsc_served_header ) && $wpsc_served_header ) {
+					header( "X-WP-Super-Cache: Served supercache 304 file from PHP" );
+				}
 				header( 'Content-Length: ' . $size );
 			} else {
-				header( "WP-Super-Cache: Served supercache file from PHP" );
+				if ( isset( $wpsc_served_header ) && $wpsc_served_header ) {
+					header( "X-WP-Super-Cache: Served supercache file from PHP" );
+				}
 			}
 
 			// don't try to match modified dates if using dynamic code.
@@ -304,7 +310,9 @@ function wp_cache_serve_cache_file() {
 		if( strpos( $header, 'Last-Modified:' ) === false )
 			header($header);
 	}
-	header( 'WP-Super-Cache: Served WPCache cache file' );
+	if ( isset( $wpsc_served_header ) && $wpsc_served_header ) {
+		header( 'X-WP-Super-Cache: Served WPCache cache file' );
+	}
 	if ( $wp_cache_object_cache ) {
 		if ( $cache ) {
 			if ( $ungzip ) {


### PR DESCRIPTION
Set $wpsc_served_header to true to show a "Served by" header when
serving cached pages. It's now off by default.
ref: https://wordpress.org/support/topic/feature-request-suppress-wp-super-cache-header/