### PR TITLE
Fix CDN urls so the right URLs are used for transforming static objects.

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -4,8 +4,8 @@
 
 /* Set up some defaults */
 if ( get_option( 'ossdl_off_cdn_url' ) == false )
-	add_option('ossdl_off_cdn_url', get_home_url() );
-$ossdl_off_blog_url = apply_filters( 'ossdl_off_blog_url', get_home_url() );
+	add_option( 'ossdl_off_cdn_url', get_option( 'siteurl' ) );
+$ossdl_off_blog_url = apply_filters( 'ossdl_off_blog_url', get_option( 'siteurl' ) );
 $ossdl_off_cdn_url = trim( get_option('ossdl_off_cdn_url') );
 if ( get_option( 'ossdl_off_include_dirs' ) == false )
 	add_option('ossdl_off_include_dirs', 'wp-content,wp-includes');
@@ -158,7 +158,7 @@ function scossdl_off_options() {
 	$example_cnames .= ',' . str_replace( 'http://cdn.', 'http://cdn2.', $example_cdn_uri );
 	$example_cnames .= ',' . str_replace( 'http://cdn.', 'http://cdn3.', $example_cdn_uri );
 
-	$example_cdn_uri = get_option('ossdl_off_cdn_url') == get_home_url() ? $example_cdn_uri : get_option('ossdl_off_cdn_url');
+	$example_cdn_uri = get_option('ossdl_off_cdn_url') == get_option( 'siteurl' ) ? $example_cdn_uri : get_option('ossdl_off_cdn_url');
 	$example_cdn_uri .= '/wp-includes/js/jquery/jquery-migrate.js';
 	?>
 		<p><?php _e( 'Your website probably uses lots of static files. Image, Javascript and CSS files are usually static files that could just as easily be served from another site or CDN. Therefore, this plugin replaces any links in the <code>wp-content</code> and <code>wp-includes</code> directories (except for PHP files) on your site with the URL you provide below. That way you can either copy all the static content to a dedicated host or mirror the files to a CDN by <a href="https://knowledgelayer.softlayer.com/faq/how-does-origin-pull-work" target="_blank">origin pull</a>.', 'wp-super-cache' ); ?></p>

--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -149,7 +149,7 @@ function scossdl_off_update() {
 }
 
 function scossdl_off_options() {
-	global $ossdlcdn, $wp_cache_config_file, $valid_nonce;
+	global $ossdlcdn, $wp_cache_config_file, $valid_nonce, $ossdl_off_blog_url;
 
 	scossdl_off_update();
 
@@ -163,6 +163,11 @@ function scossdl_off_options() {
 	?>
 		<p><?php _e( 'Your website probably uses lots of static files. Image, Javascript and CSS files are usually static files that could just as easily be served from another site or CDN. Therefore, this plugin replaces any links in the <code>wp-content</code> and <code>wp-includes</code> directories (except for PHP files) on your site with the URL you provide below. That way you can either copy all the static content to a dedicated host or mirror the files to a CDN by <a href="https://knowledgelayer.softlayer.com/faq/how-does-origin-pull-work" target="_blank">origin pull</a>.', 'wp-super-cache' ); ?></p>
 		<p><?php printf( __( '<strong style="color: red">WARNING:</strong> Test some static urls e.g., %s  to ensure your CDN service is fully working before saving changes.', 'wp-super-cache' ), '<code>' . $example_cdn_uri . '</code>' ); ?></p>
+
+	<?php if ( $ossdl_off_blog_url != get_home_url() ) { ?>
+		<p><?php printf( __( '<strong style="color: red">WARNING:</strong> Your siteurl and homeurl are different. The plugin is using %s as the homepage URL of your site but if that is wrong please use the filter "ossdl_off_blog_url" to fix it.', 'wp-super-cache' ), '<code>' . $ossdl_off_blog_url . '</code>' ); ?></p>
+	<?php } ?> 
+
 		<p><?php _e( 'You can define different CDN URLs for each site on a multsite network.', 'wp-super-cache' ); ?></p>
 		<p><form method="post" action="">
 		<?php wp_nonce_field('wp-cache'); ?>


### PR DESCRIPTION
This reverts the changes in #26 plus adds a note warning users of sites with differing site url and home url to use a filter to correct the URL.