### PR TITLE
The cache dir is already deleted before deletion. No need for this.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -137,8 +137,6 @@ function wpsupercache_uninstall() {
 	if ( !function_exists( 'prune_super_cache' ) )
 		include_once( 'wp-cache-phase2.php' );
 
-	prune_super_cache( $cache_path, true );
-
 	wp_cache_remove_index();
 
 	if ( null !== $cache_path && '' !== $cache_path ) {


### PR DESCRIPTION
The deactivate function has already deleted the cache directory so
there's no need to do the same thing in the uninstall function.