### PR TITLE
Add "site url" setting to CDN page to avoid problems with that setting

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -5,7 +5,9 @@
 /* Set up some defaults */
 if ( get_option( 'ossdl_off_cdn_url' ) == false )
 	add_option( 'ossdl_off_cdn_url', get_option( 'siteurl' ) );
-$ossdl_off_blog_url = apply_filters( 'ossdl_off_blog_url', get_option( 'siteurl' ) );
+if ( get_option( 'ossdl_off_blog_url' ) == false )
+	add_option( 'ossdl_off_blog_url', apply_filters( 'ossdl_off_blog_url', untrailingslashit( get_option( 'siteurl' ) ) ) );
+$ossdl_off_blog_url = get_option( 'ossdl_off_blog_url' );
 $ossdl_off_cdn_url = trim( get_option('ossdl_off_cdn_url') );
 if ( get_option( 'ossdl_off_include_dirs' ) == false )
 	add_option('ossdl_off_include_dirs', 'wp-content,wp-includes');
@@ -132,7 +134,8 @@ function scossdl_off_update() {
 	global $ossdlcdn, $wp_cache_config_file, $valid_nonce;
 
 	if ( $valid_nonce && isset($_POST['action']) && ( $_POST['action'] == 'update_ossdl_off' )){
-		update_option('ossdl_off_cdn_url', $_POST['ossdl_off_cdn_url']);
+		update_option( 'ossdl_off_cdn_url', untrailingslashit( $_POST[ 'ossdl_off_cdn_url' ] ) );
+		update_option( 'ossdl_off_blog_url', untrailingslashit( $_POST[ 'ossdl_off_blog_url' ] ) );
 		update_option('ossdl_off_include_dirs', $_POST['ossdl_off_include_dirs'] == '' ? 'wp-content,wp-includes' : $_POST['ossdl_off_include_dirs']);
 		update_option('ossdl_off_exclude', $_POST['ossdl_off_exclude']);
 		update_option('ossdl_cname', $_POST['ossdl_cname']);
@@ -177,6 +180,13 @@ function scossdl_off_options() {
 					<input id='ossdlcdn' type="checkbox" name="ossdlcdn" value="1" <?php if ( $ossdlcdn ) echo "checked=1"; ?> />
 				</td>
 				<th scope="row"><label for="ossdlcdn"><?php _e( 'Enable CDN Support', 'wp-super-cache' ); ?></label></th>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="ossdl_off_cdn_url"><?php _e( 'Site URL', 'wp-super-cache' ); ?></label></th>
+				<td>
+					<input type="text" name="ossdl_off_blog_url" value="<?php echo esc_url( untrailingslashit( get_option( 'ossdl_off_blog_url' ) ) ); ?>" size="64" class="regular-text code" /><br />
+					<span class="description"><?php _e( 'The URL of your site. No trailing <code>/</code> please.', 'wp-super-cache' ); ?></span>
+				</td>
 			</tr>
 			<tr valign="top">
 				<th scope="row"><label for="ossdl_off_cdn_url"><?php _e( 'Off-site URL', 'wp-super-cache' ); ?></label></th>

--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -53,6 +53,16 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 	/**
 	 * @return string
 	 */
+	public function get_ossdl_off_blog_url() {
+		$url = get_option( 'ossdl_off_blog_url' );
+		if ( ! $url )
+			$url = apply_filters( 'ossdl_off_blog_url', untrailingslashit( get_option( 'siteurl' ) ) );
+		return $url;
+	}
+
+	/**
+	 * @return string
+	 */
 	public function get_cache_path_url() {
 		global $cache_path;
 

--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -384,6 +384,13 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 	/**
 	 * @param mixed $value
 	 */
+	protected function set_ossdl_off_blog_url( $value ) {
+		update_option( 'ossdl_off_blog_url', untrailingslashit( $value ) );
+	}
+
+	/**
+	 * @param mixed $value
+	 */
 	protected function set_ossdl_off_cdn_url( $value ) {
 		update_option( 'ossdl_off_cdn_url', $value );
 	}

--- a/rest/class.wp-super-cache-settings-map.php
+++ b/rest/class.wp-super-cache-settings-map.php
@@ -216,6 +216,10 @@ class WP_Super_Cache_Settings_Map {
 			'option' => 'ossdl_off_cdn_url',
 			'set'    => 'set_ossdl_off_cdn_url',
 		),
+		'ossdl_off_blog_url' => array(
+			'option' => 'ossdl_off_blog_url',
+			'set'    => 'set_ossdl_off_blog_url',
+		),
 		'ossdl_off_exclude' => array(
 			'option' => 'ossdl_off_exclude',
 			'set'    => 'set_ossdl_off_exclude',


### PR DESCRIPTION
WordPress installs "in their own directory" will sometimes have
different siteurl and home url which can cause problems. This setting
will allow the site administrator to set it correctly.