### PR TITLE
Don't enable (and then not save) debug comments when toggling logging

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1995,9 +1995,6 @@ function wpsc_update_debug_settings() {
 		}
 	}
 
-	if ( false == isset( $wp_super_cache_comments ) )
-		$wp_super_cache_comments = 1;
-
 	if ( isset( $_POST[ 'wp_cache_debug' ] ) ) {
 		wp_cache_setting( 'wp_cache_debug_username', $wp_cache_debug_username );
 		wp_cache_setting( 'wp_cache_debug_log', $wp_cache_debug_log );


### PR DESCRIPTION
If you toggle debug logging on/off it appears that debug comments are
enabled but they may not be. ref:
https://wordpress.org/support/topic/wp-super-cache-v1-5-0-not-adding-source-footer-comments/