### PR TITLE
Show html comments to logged in users when their caching disabled.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -48,7 +48,6 @@ if( is_array( $plugins ) ) {
 
 if ( $wp_cache_not_logged_in && wp_cache_get_cookies_values() ) {
 	wp_cache_debug( 'Caching disabled for logged in users on settings page.' );
-	define( 'DONOTCACHEPAGE', 1 );
 	return true;
 }
 


### PR DESCRIPTION
If caching is disabled for logged in users we still should show them
html comments if enabled.
See https://wordpress.org/support/topic/wp-super-cache-v1-5-0-not-adding-source-footer-comments/