### PR TITLE
If a cached feed is newer than most recently updated post then use it.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -194,6 +194,21 @@ function wp_cache_serve_cache_file() {
 			@unlink( $cache_file );
 			return true;
 		}
+		// check for updated feed
+		if ( isset( $meta[ 'headers' ][ 'Content-Type' ] ) ) {
+			$rss_types = apply_filters( 'wpsc_rss_types', array( 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml' ) );
+			foreach( $rss_types as $rss_type ) {
+				if ( strpos( $meta[ 'headers' ][ 'Content-Type' ], $rss_type ) ) {
+					global $wpsc_last_post_update;
+					if ( isset( $wpsc_last_post_update ) && filemtime( $meta_pathname ) < $wpsc_last_post_update ) {
+						wp_cache_debug( "wp_cache_serve_cache_file: feed out of date. deleting cache files: $meta_pathname, $cache_file" );
+						@unlink( $meta_pathname );
+						@unlink( $cache_file );
+						return true;
+					}
+				}
+			}
+		}
 	} else { // no $cache_file
 		global $wpsc_save_headers;
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1622,4 +1622,9 @@ function wp_cache_gc_watcher() {
 	}
 }
 
+function wpsc_timestamp_cache_update( $type, $permalink ) {
+	wp_cache_setting( 'wpsc_last_post_update', time() );
+}
+add_action( 'gc_cache', 'wpsc_timestamp_cache_update', 10, 2 );
+
 ?>


### PR DESCRIPTION
If the cache of a feed is older than the most recently updated post then
delete the cached feed and force a regeneration. ref:
https://wordpress.org/support/topic/rss-feed-not-being-seen-as-updated-by-third-party-readers/