### PR TITLE
OSSDL CDN: Only check nonce on relevant page loads

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -125,13 +125,10 @@ if ( false == isset( $ossdlcdn ) )
 if ( $ossdlcdn == 1 )
 	add_action('init', 'do_scossdl_off_ob_start');
 
-if ( function_exists( 'wp_verify_nonce' ) )
-	$valid_nonce = isset($_REQUEST['_wpnonce']) ? wp_verify_nonce($_REQUEST['_wpnonce'], 'wp-cache') : false;
-else
-	$valid_nonce = false;
-
 function scossdl_off_update() {
 	global $ossdlcdn, $wp_cache_config_file, $valid_nonce;
+
+	$valid_nonce = isset($_REQUEST['_wpnonce']) ? wp_verify_nonce($_REQUEST['_wpnonce'], 'wp-cache') : false;
 
 	if ( $valid_nonce && isset($_POST['action']) && ( $_POST['action'] == 'update_ossdl_off' )){
 		update_option( 'ossdl_off_cdn_url', untrailingslashit( $_POST[ 'ossdl_off_cdn_url' ] ) );
@@ -152,7 +149,7 @@ function scossdl_off_update() {
 }
 
 function scossdl_off_options() {
-	global $ossdlcdn, $wp_cache_config_file, $valid_nonce, $ossdl_off_blog_url;
+	global $ossdlcdn, $wp_cache_config_file, $ossdl_off_blog_url;
 
 	scossdl_off_update();
 

--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -126,7 +126,7 @@ if ( $ossdlcdn == 1 )
 	add_action('init', 'do_scossdl_off_ob_start');
 
 function scossdl_off_update() {
-	global $ossdlcdn, $wp_cache_config_file, $valid_nonce;
+	global $ossdlcdn, $wp_cache_config_file;
 
 	$valid_nonce = isset($_REQUEST['_wpnonce']) ? wp_verify_nonce($_REQUEST['_wpnonce'], 'wp-cache') : false;
 


### PR DESCRIPTION
In **ossdl-cdn.php** this code is in the global scope:

```php
if ( function_exists( 'wp_verify_nonce' ) )
	$valid_nonce = isset($_REQUEST['_wpnonce']) ?
	 wp_verify_nonce($_REQUEST['_wpnonce'], 'wp-cache') : false;
else
	$valid_nonce = false;
```

So it runs on every request, and because the file is included when the
plugin first loads, it seems to happen before `wp_verify_nonce` is
defined, so it probably is always set to `false` under normal
circumstances.

The `wp_verify_nonce` function is pluggable, though, so if an override
for it gets defined elsewhere by a plugin or something, it might
actually be defined when the above nonce check happens. This then throws
a fatal error because `wp_verify_nonce` uses `wp_get_current_user`,
which is _not_ defined this early.

This commit addresses the issue by moving the nonce check inside the
only function in the file that uses the `$valid_nonce` variable,
`scossdl_off_update`. The `scossdl_off_options` lists this variable
as a global as well, but it's never used, so the commit also removes
that reference.