### PR TITLE
Ignore $super_cache_enabled and return correct cache type

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -79,14 +79,10 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 		}
 		include( $wp_cache_config_file );
 
-		if ( $super_cache_enabled ) {
-			if ( $wp_cache_mod_rewrite == 1 ) {
-				return 'mod_rewrite';
-			} else {
-				return 'PHP';
-			}
+		if ( $wp_cache_mod_rewrite == 1 ) {
+			return 'mod_rewrite';
 		} else {
-			return 'wpcache';
+			return 'PHP';
 		}
 	}
 


### PR DESCRIPTION
If $super_cache_enabled was disabled the "cache_type" would fallback to "wpcache" which isn't correct because you can't really disable PHP or mod_rewrite modes.