### PR TITLE
Add support for Jetpack-beta, load UA file only if function missing

### DIFF
--- a/plugins/jetpack.php
+++ b/plugins/jetpack.php
@@ -50,16 +50,23 @@ function wp_super_cache_jetpack_admin() {
 add_cacheaction( 'cache_admin_page', 'wp_super_cache_jetpack_admin' );
 
 function wp_super_cache_jetpack_cookie_check( $cache_key ) {
-	if ( file_exists( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' ) ) {
-		if ( function_exists( "jetpack_is_mobile" ) == false )
-			include( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' );
+	if ( function_exists( "jetpack_is_mobile" ) == false ) {
 
+		if ( file_exists( dirname( WPCACHEHOME ) . '/jetpack-dev/class.jetpack-user-agent.php' ) ) {
+			include( dirname( WPCACHEHOME ) . '/jetpack-dev/class.jetpack-user-agent.php' );
+		} elseif ( file_exists( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' ) ) {
+			include( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' );
+		} else {
+			wp_cache_debug( "wp_super_cache_jetpack_cookie_check: jetpack UA file not found." );
+		}
+	}
+
+	if ( function_exists( "jetpack_is_mobile" ) ) {
 		if ( jetpack_is_mobile() )
 			return 'mobile';
 		else
 			return 'normal';
 	} else {
-		wp_cache_debug( "wp_super_cache_jetpack_cookie_check: jetpack UA file not found." );
 		return "normal";
 	}
 }


### PR DESCRIPTION
Fixes #298
The plugin should only load the Jetpack user agent code if
jetpack_is_mobile() doesn't exist, and try the dev directory first,
just in case that's installed.