### PR TITLE
Don't load jetpack mobile file if jetpack-dev detected.

### DIFF
--- a/plugins/jetpack.php
+++ b/plugins/jetpack.php
@@ -53,7 +53,8 @@ function wp_super_cache_jetpack_cookie_check( $cache_key ) {
 	if ( function_exists( "jetpack_is_mobile" ) == false ) {
 
 		if ( file_exists( dirname( WPCACHEHOME ) . '/jetpack-dev/class.jetpack-user-agent.php' ) ) {
-			include_once( dirname( WPCACHEHOME ) . '/jetpack-dev/class.jetpack-user-agent.php' );
+			wp_cache_debug( "wp_super_cache_jetpack_cookie_check: jetpack dev detected. Returning 'normal' to avoid loading Jetpack." );
+			return "normal";
 		} elseif ( file_exists( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' ) ) {
 			include_once( dirname( WPCACHEHOME ) . '/jetpack/class.jetpack-user-agent.php' );
 		} else {


### PR DESCRIPTION
Fixes #298
Hopefully fixes #298, finally. The previous fix using include_once()
worked for some time on my site and then stopped with an error about
redeclaring the class in that file.