### PR TITLE
Don't delete child pages on preload

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3346,7 +3346,11 @@ function clear_post_supercache( $post_id ) {
 		include_once( 'wp-cache-phase2.php' );
 
 	wp_cache_debug( "clear_post_supercache: deleting files in $dir", 2 );
-	prune_super_cache( $dir, true );
+	if ( get_post_type( $post_id ) != 'page' ) { // don't delete child pages if they exist
+		prune_super_cache( $dir, true );
+	} else {
+		wpsc_delete_files( $dir );
+	}
 }
 
 function wp_cron_preload_cache() {


### PR DESCRIPTION
Since child pages are most likely to be created after parents pages the
preload process will create the child page before the parent page.
However, it will delete the child pages when it tries to create the
parent page. This fixes that by only deleting files in the directory if
the preloaded post is a page. ref:
https://wordpress.org/support/topic/decending-caching-order-causes-deletion-of-child-pages/