### PR TITLE
Give feeds on blogs with the plugin inactive a short TTL

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -200,7 +200,8 @@ function wp_cache_serve_cache_file() {
 			foreach( $rss_types as $rss_type ) {
 				if ( strpos( $meta[ 'headers' ][ 'Content-Type' ], $rss_type ) ) {
 					global $wpsc_last_post_update;
-					if ( isset( $wpsc_last_post_update ) && filemtime( $meta_pathname ) < $wpsc_last_post_update ) {
+					if ( isset( $wpsc_last_post_update ) && filemtime( $meta_pathname ) < $wpsc_last_post_update ||
+						( isset( $meta[ 'ttl' ] ) && ( time() - filemtime( $meta_pathname ) ) > $meta[ 'ttl' ] ) ) {
 						wp_cache_debug( "wp_cache_serve_cache_file: feed out of date. deleting cache files: $meta_pathname, $cache_file" );
 						@unlink( $meta_pathname );
 						@unlink( $cache_file );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1098,6 +1098,16 @@ function wp_cache_shutdown_callback() {
 	global $wp_cache_request_uri, $wp_cache_key, $wp_cache_object_cache, $cache_enabled, $wp_cache_blog_charset, $wp_cache_not_logged_in;
 	global $WPSC_HTTP_HOST, $wp_super_cache_query;
 
+	if ( function_exists( 'wpsc_init' ) ) {
+		/*
+		 * If a server has multiple networks the plugin may not have been activated
+		 * on all of them. Give feeds on those blogs a short TTL.
+		 * ref: https://wordpress.org/support/topic/fatal-error-while-updating-post-or-publishing-new-one/
+		 */
+		$wpsc_feed_ttl = 1;
+	}
+
+
 	if ( false == $new_cache ) {
 		wp_cache_debug( "wp_cache_shutdown_callback: No cache file created. Returning." );
 		return false;
@@ -1150,10 +1160,18 @@ function wp_cache_shutdown_callback() {
 						$value = "application/rss+xml";
 					}
 			}
+			if ( isset( $wpsc_feed_ttl ) && $wpsc_feed_ttl == 1 ) {
+				$wp_cache_meta[ 'ttl' ] = 60;
+			}
+
 			wp_cache_debug( "wp_cache_shutdown_callback: feed is type: $type - $value" );
 		} elseif ( get_query_var( 'sitemap' ) || get_query_var( 'xsl' ) || get_query_var( 'xml_sitemap' ) ) {
 			wp_cache_debug( "wp_cache_shutdown_callback: sitemap detected: text/xml" );
 			$value = "text/xml";
+			if ( isset( $wpsc_feed_ttl ) && $wpsc_feed_ttl == 1 ) {
+				$wp_cache_meta[ 'ttl' ] = 60;
+			}
+
 		} else { // not a feed
 			$value = get_option( 'html_type' );
 			if( $value == '' )
@@ -1641,10 +1659,5 @@ function wp_cache_gc_watcher() {
 		schedule_wp_gc();
 	}
 }
-
-function wpsc_timestamp_cache_update( $type, $permalink ) {
-	wp_cache_setting( 'wpsc_last_post_update', time() );
-}
-add_action( 'gc_cache', 'wpsc_timestamp_cache_update', 10, 2 );
 
 ?>

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1098,13 +1098,14 @@ function wp_cache_shutdown_callback() {
 	global $wp_cache_request_uri, $wp_cache_key, $wp_cache_object_cache, $cache_enabled, $wp_cache_blog_charset, $wp_cache_not_logged_in;
 	global $WPSC_HTTP_HOST, $wp_super_cache_query;
 
-	if ( function_exists( 'wpsc_init' ) ) {
+	if ( ! function_exists( 'wpsc_init' ) ) {
 		/*
 		 * If a server has multiple networks the plugin may not have been activated
 		 * on all of them. Give feeds on those blogs a short TTL.
 		 * ref: https://wordpress.org/support/topic/fatal-error-while-updating-post-or-publishing-new-one/
 		 */
 		$wpsc_feed_ttl = 1;
+		wp_cache_debug( "wp_cache_shutdown_callback: Plugin not loaded. Setting feed ttl to 60 seconds." );
 	}
 
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3958,3 +3958,9 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 
 	return true;
 }
+
+function wpsc_timestamp_cache_update( $type, $permalink ) {
+	wp_cache_setting( 'wpsc_last_post_update', time() );
+}
+add_action( 'gc_cache', 'wpsc_timestamp_cache_update', 10, 2 );
+


### PR DESCRIPTION
Some servers have several networks running on one install and the server
admin may forget to activate the plugin on each network. Or a network
admin may disable the plugin for some reason on one blog, but caching
will still occur because it's loaded by WordPress because the WP_CACHE
constant is defined.
Unfortunately this stops wp-cache.php loading where wp_cache_setting()
is defined. That function is used to write a timestamp to the config
file whenever a post is updated. When the plugin is inactive, the feeds
will be given a TTL of 60 seconds so they do not become stale.
ref:
https://wordpress.org/support/topic/fatal-error-while-updating-post-or-publishing-new-one/