### PR TITLE
Make sure wp_query is defined before using it.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -351,7 +351,10 @@ function wp_cache_writers_exit() {
 }
 
 function wp_super_cache_query_vars() {
-	global $wp_super_cache_query;
+	global $wp_super_cache_query, $wp_query;
+	if ( empty( $wp_query ) ) {
+		$wp_query = new WP_Query();
+	}
 	if ( is_search() )
 		$wp_super_cache_query[ 'is_search' ] = 1;
 	if ( is_page() )


### PR DESCRIPTION
Some sites die() before creating $wp_query. This fix creates that object.
It may avoid fatal errors for those users but it's likely the page
type detection will not work.
ref: https://wordpress.org/support/topic/fatal-error-with-latest-update-4/#post-9437870