### PR TITLE
Add redirects/rest api/is_robots into wp-cache-phase2.php

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3078,11 +3078,14 @@ if( get_option( 'gzipcompression' ) )
 // Catch 404 requests. Themes that use query_posts() destroy $wp_query->is_404
 function wp_cache_catch_404() {
 	global $wp_cache_404;
+	if ( function_exists( '_deprecated_function' ) )
+		_deprecated_function( __FUNCTION__, 'WP Super Cache 1.5.6' );
 	$wp_cache_404 = false;
 	if( is_404() )
 		$wp_cache_404 = true;
 }
-add_action( 'template_redirect', 'wp_cache_catch_404' );
+//More info - https://github.com/Automattic/wp-super-cache/pull/373
+//add_action( 'template_redirect', 'wp_cache_catch_404' );
 
 function wp_cache_favorite_action( $actions ) {
 	if ( false == wpsupercache_site_admin() )


### PR DESCRIPTION
This PR covers some cases of 'unknown page type':
* Use filter [wp_redirect_status](https://developer.wordpress.org/reference/hooks/wp_redirect_status/) and function [http_response_code](http://php.net/manual/en/function.http-response-code.php) to catch all possible redirects.
* Use filter [status_header](https://developer.wordpress.org/reference/hooks/status_header/)  to catch status code for PHP 5.2 and 5.3.
* Use constants `REST_REQUEST` and `JSON_REQUEST` for REST API. I think that covers all WP versions.
* Use constant `WC_API_REQUEST` for detection of [WooCommerce REST API](http://woocommerce.github.io/woocommerce-rest-api-docs/).
* Use [is_robots](https://developer.wordpress.org/reference/functions/is_robots/) and add it into `$wp_super_cache_query`.

Minor corrections:
* Fix typo for filter `wpsc_only_cache_known_pages`.
* Move filter `wp_cache_ob_callback_filter` after call of `wp_super_cache_query_vars`. It's better because it's possible to use `$wp_super_cache_query`. (eg. for sitemaps/feeds detection)
* Use `$wp_super_cache_query[ 'is_404' ]` instead `$wp_cache_404` (and hook `wp_cache_catch_404` )

