### PR TITLE
Don't set this as it's not always saved when this function is called.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1986,9 +1986,6 @@ function wpsc_update_debug_settings() {
 	global $wp_super_cache_front_page_check, $wp_super_cache_front_page_clear, $wp_super_cache_front_page_text, $wp_super_cache_front_page_notification, $wp_super_cache_advanced_debug;
 	global $wp_cache_debug_username;
 
-	if ( false == isset( $wp_super_cache_comments ) )
-		$wp_super_cache_comments = 1;
-
 	if ( false == $valid_nonce ) {
 		return array (
 			'wp_super_cache_debug' => $wp_super_cache_debug,


### PR DESCRIPTION
This function is called when the debug log is toggled, so setting this
here can confuse users who think that cache comments are active. It's
set further down in the function.