### PR TITLE
Fixes PHP notices (#383) and improve detects of backend request

### DIFF
--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -2,11 +2,6 @@
 if ( false == isset( $_SERVER[ 'HTTP_HOST' ] ) ) {
 	$cache_enabled = false;
 	$WPSC_HTTP_HOST = '';
-/* We should find better place for this
-	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-		// Workaround for php-cli wp-cron.php and wp-cli.
-		$WPSC_HTTP_HOST = parse_url( get_option( 'home' ), PHP_URL_HOST );
-	}*/
 } else {
 	$WPSC_HTTP_HOST = htmlentities( $_SERVER[ 'HTTP_HOST' ] );
 }

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -2,6 +2,10 @@
 if ( false == isset( $_SERVER[ 'HTTP_HOST' ] ) ) {
 	$cache_enabled = false;
 	$WPSC_HTTP_HOST = '';
+	if ( ( defined( 'DOING_CRON' ) && DOING_CRON ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+		// Workaround for php-cli wp-cron.php and wp-cli.
+		$WPSC_HTTP_HOST = parse_url( get_option( 'home' ), PHP_URL_HOST );
+	}
 } else {
 	$WPSC_HTTP_HOST = htmlentities( $_SERVER[ 'HTTP_HOST' ] );
 }

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -686,7 +686,9 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$uri = strtolower( $wp_cache_request_uri );
 	}
 	$uri = wpsc_deep_replace( array( '..', '\\', 'index.php', ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( "/(\?.*)?(#.*)?$/", '', $uri ) ) );
-	$dir = preg_replace( '/:.*$/', '',  $WPSC_HTTP_HOST ) . $uri; // To avoid XSS attacks
+	// Get hostname from wp options for wp-cron, wp-cli and similar requests.
+	$hostname = empty( $WPSC_HTTP_HOST ) ? (string) parse_url( get_option( 'home' ), PHP_URL_HOST ) : $WPSC_HTTP_HOST;
+	$dir = preg_replace( '/:.*$/', '', $hostname ) . $uri; // To avoid XSS attacks
 	if ( function_exists( "apply_filters" ) ) {
 		$dir = apply_filters( 'supercache_dir', $dir );
 	} else {

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -671,16 +671,19 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$permalink = get_permalink( $post_id );
 		if ( false === strpos( $permalink, $site_url ) ) {
 			/*
-			 * Sometimes site_url doesn't return the siteurl. See http://wordpress.org/support/topic/wp-super-cache-not-refreshing-post-after-comments-made
-			*/
+			 * Sometimes site_url doesn't return the siteurl. See https://wordpress.org/support/topic/wp-super-cache-not-refreshing-post-after-comments-made
+			 */
 			$DONOTREMEMBER = 1;
 			wp_cache_debug( "get_current_url_supercache_dir: WARNING! site_url ($site_url) not found in permalink ($permalink).", 1 );
-			if ( preg_match( '#^(https?:)?//([^/]+)(/[^\?\#]*)?((\?|\#).*)?$#i', $permalink, $matches ) && !empty( $matches[2] ) ) {
+			if ( preg_match( '`^(https?:)?//([^/]+)(/.*)?$`i', $permalink, $matches ) ) {
 				if ( $WPSC_HTTP_HOST != $matches[2] ) {
 					wp_cache_debug( "get_current_url_supercache_dir: WARNING! SERVER_NAME ({$WPSC_HTTP_HOST}) not found in permalink ($permalink).", 1 );
 				}
 				wp_cache_debug( "get_current_url_supercache_dir: Removing SERVER_NAME ({$matches[2]}) from permalink ($permalink). Is the url right?", 1 );
 				$uri = isset( $matches[3] ) ? $matches[3] : '';
+			} elseif ( preg_match( '`^/([^/]+)(/.*)?$`i', $permalink, $matches ) ) {
+				wp_cache_debug( "get_current_url_supercache_dir: WARNING! Permalink ($permalink) looks as absolute path. Is the url right?", 1 );
+				$uri = $permalink;
 			} else {
 				wp_cache_debug( "get_current_url_supercache_dir: WARNING! Permalink ($permalink) could not be understood by parsing url. Using front page.", 1 );
 				$uri = '';
@@ -693,7 +696,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 	} else {
 		$uri = strtolower( $wp_cache_request_uri );
 	}
-	$uri = wpsc_deep_replace( array( '..', '\\', 'index.php', ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( "/(\?.*)?$/", '', $uri ) ) );
+	$uri = wpsc_deep_replace( array( '..', '\\', 'index.php', ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( "/(\?.*)?(#.*)?$/", '', $uri ) ) );
 	$dir = preg_replace( '/:.*$/', '',  $WPSC_HTTP_HOST ) . $uri; // To avoid XSS attacks
 	if ( function_exists( "apply_filters" ) ) {
 		$dir = apply_filters( 'supercache_dir', $dir );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -44,13 +44,13 @@ function wp_cache_phase2() {
 		do_cacheaction( 'add_cacheaction' );
 	}
 
-	if ( is_admin() ) {
+	if ( wpsc_is_backend() ) {
 		wp_cache_debug( 'Not caching wp-admin requests.', 5 );
 		return false;
 	}
 
-	if ( !empty( $_GET ) && !defined( "DOING_CRON" ) ) {
-		wp_cache_debug( 'Supercache caching disabled. Only using wp-cache. Non empty GET request. ' . json_encode( $_GET ), 5 );
+	if ( !empty( $_GET ) ) {
+		wp_cache_debug( 'Supercache caching disabled. Only using wp-cache. Non empty GET request. ' . wpsc_dump_get_request(), 5 );
 		$super_cache_enabled = false;
 	}
 
@@ -415,8 +415,8 @@ function wp_cache_ob_callback( $buffer ) {
 	} elseif ( defined( 'DONOTCACHEPAGE' ) ) {
 		wp_cache_debug( 'DONOTCACHEPAGE defined. Caching disabled.', 2 );
 		$cache_this_page = false;
-	} elseif ( $wp_cache_no_cache_for_get && false == empty( $_GET ) && false == defined( 'DOING_CRON' ) ) {
-		wp_cache_debug( "Non empty GET request. Caching disabled on settings page. " . json_encode( $_GET ), 1 );
+	} elseif ( $wp_cache_no_cache_for_get && false == empty( $_GET ) ) {
+		wp_cache_debug( "Non empty GET request. Caching disabled on settings page. " . wpsc_dump_get_request(), 1 );
 		$cache_this_page = false;
 	} elseif ( $_SERVER["REQUEST_METHOD"] == 'POST' || !empty( $_POST ) || get_option( 'gzipcompression' ) ) {
 		wp_cache_debug( 'Not caching POST request.', 5 );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2263,7 +2263,7 @@ function wp_cache_remove_index() {
 				}
 				if ( is_dir( $directory . "/meta" ) ) {
 					if ( is_file( $directory . "/meta/index.html" ) ) {
-						unlink( $directory . "/index.html" );
+						unlink( $directory . "/meta/index.html" );
 					}
 				}
 			}

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2461,7 +2461,7 @@ function wp_cache_verify_config_file() {
 		}
 		$new = true;
 	}
-	if( $sem_id == 5419 && $cache_path != '' ) {
+	if ( $sem_id == 5419 && $cache_path != '' && $WPSC_HTTP_HOST != '' ) {
 		$sem_id = crc32( $WPSC_HTTP_HOST . $cache_path ) & 0x7fffffff;
 		wp_cache_replace_line('sem_id', '$sem_id = ' . $sem_id . ';', $wp_cache_config_file);
 	}


### PR DESCRIPTION
* Use [wp_json_encode](https://developer.wordpress.org/reference/functions/wp_json_encode/) if this function exists (WP Core >= 4.1.0). It fixes #349
* Introduce `wpsc_is_backend`
* Improve `get_current_url_supercache_dir` by using regular expressions
* Additional checking for `$WPSC_HTTP_HOST`