### PR TITLE
Check that wp_cache_setting exists before using it.

### DIFF
--- a/plugins/searchengine.php
+++ b/plugins/searchengine.php
@@ -59,7 +59,7 @@ function wpsc_get_searchengine_setting() {
 		$cache_no_adverts_for_friends = 0;
 		$changed = true;
 	}
-	if ( $changed ) {
+	if ( $changed && function_exists( 'wp_cache_setting' ) ) {
 		wp_cache_setting( 'cache_no_adverts_for_friends', $cache_no_adverts_for_friends );
 	}
 


### PR DESCRIPTION
Fixes #398
Plugins are loaded really early so not everything is loaded including
this function.