### PR TITLE
Update feeds when site updates

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -194,22 +194,6 @@ function wp_cache_serve_cache_file() {
 			@unlink( $cache_file );
 			return true;
 		}
-		// check for updated feed
-		if ( isset( $meta[ 'headers' ][ 'Content-Type' ] ) ) {
-			$rss_types = apply_filters( 'wpsc_rss_types', array( 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml' ) );
-			foreach( $rss_types as $rss_type ) {
-				if ( strpos( $meta[ 'headers' ][ 'Content-Type' ], $rss_type ) ) {
-					global $wpsc_last_post_update;
-					if ( isset( $wpsc_last_post_update ) && filemtime( $meta_pathname ) < $wpsc_last_post_update ||
-						( isset( $meta[ 'ttl' ] ) && ( time() - filemtime( $meta_pathname ) ) > $meta[ 'ttl' ] ) ) {
-						wp_cache_debug( "wp_cache_serve_cache_file: feed out of date. deleting cache files: $meta_pathname, $cache_file" );
-						@unlink( $meta_pathname );
-						@unlink( $cache_file );
-						return true;
-					}
-				}
-			}
-		}
 	} else { // no $cache_file
 		global $wpsc_save_headers;
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3979,10 +3979,20 @@ function update_mod_rewrite_rules( $add_rules = true ) {
 	return true;
 }
 
-function wpsc_timestamp_cache_update( $type, $permalink ) {
-	wp_cache_setting( 'wpsc_last_post_update', time() );
+// Delete feeds when the site is updated so that feed files are always fresh
+function wpsc_feed_update( $type, $permalink ) {
+	$wpsc_feed_list = get_option( 'wpsc_feed_list' );
+
+	update_option( 'wpsc_feed_list', array() );
+	if ( is_array( $wpsc_feed_list ) && ! empty( $wpsc_feed_list ) ) {
+		foreach( $wpsc_feed_list as $file ) {
+			wp_cache_debug( "wpsc_feed_update: deleting feed: $file" );
+			@unlink( $file );
+			@unlink( dirname( $file ) . '/meta-' . basename( $file ) );
+		}
+	}
 }
-add_action( 'gc_cache', 'wpsc_timestamp_cache_update', 10, 2 );
+add_action( 'gc_cache', 'wpsc_feed_update', 10, 2 );
 
 function wpsc_get_plugin_list() {
 	$list = do_cacheaction( 'wpsc_filter_list' );


### PR DESCRIPTION
Store a record of archive feed pages that can be deleted when the cache
is updated. This will help keep feeds fresh. Do not record feeds for
single pages. A maximum of 50 feeds is recorded to avoid bloating the
options table.
Will avoid writing to the config file and causing race issues reading
and writing.