### PR TITLE
Check the query var is_feed too when caching feed locations

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1244,7 +1244,7 @@ function wp_cache_shutdown_callback() {
 
 			// record locations of archive feeds to be updated when the site is updated.
 			// Only record a maximum of 50 feeds to avoid bloating database.
-			if ( $is_feed && ! isset( $wp_super_cache_query[ 'is_single' ] ) ) {
+			if ( ( isset( $wp_super_cache_query[ 'is_feed' ] ) || $is_feed ) && ! isset( $wp_super_cache_query[ 'is_single' ] ) ) {
 				$wpsc_feed_list = (array) get_option( 'wpsc_feed_list' );
 				if ( count( $wpsc_feed_list ) <= 50 ) {
 					$wpsc_feed_list[] = $dir . $meta_file;


### PR DESCRIPTION
I hardly ever see the correct content-type but when it's set then
$is_feed won't be set so check the cached query var to store the feed in
the feed_list.