### PR TITLE
Support all callables in `do_cacheaction()`

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -454,11 +454,7 @@ function do_cacheaction( $action, $value = '' ) {
 	if( array_key_exists($action, $wp_supercache_actions) && is_array( $wp_supercache_actions[ $action ] ) ) {
 		$actions = $wp_supercache_actions[ $action ];
 		foreach( $actions as $func ) {
-			if ( is_array( $func ) ) {
-				$value = $func[0]->{$func[1]}( $value );
-			} else {
-				$value = $func( $value );
-			}
+			$value = call_user_func_array( $func, array( $value ) );
 		}
 	}
 


### PR DESCRIPTION
Fixes #418 

Using `call_user_func_array()` will allow for all `callable` formats. Previously, referencing static class methods weren't supported:
```php
add_cacheaction( 'action_name', array( 'My_Awesome_Class', 'my_awesome_class_static_method' ) );
```