### PR TITLE
Move this function so it's available when wp-cache.php is not loaded

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -1051,4 +1051,16 @@ foreach( $debug_log as $line ) {
 	return array( 'wp_cache_debug_log' => $wp_cache_debug_log, 'wp_cache_debug_username' => $wp_cache_debug_username );
 }
 
+function wpsc_delete_url_cache( $url ) {
+	$dir = str_replace( get_option( 'home' ), '', $url );
+	if ( $dir != '' ) {
+		$supercachedir = get_supercache_dir();
+		wpsc_delete_files( $supercachedir . $dir );
+		prune_super_cache( $supercachedir . $dir . '/page', true );
+		return true;
+	} else {
+		return false;
+	}
+}
+
 ?>

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2936,18 +2936,6 @@ function wp_cache_clean_cache( $file_prefix, $all = false ) {
 
 }
 
-function wpsc_delete_url_cache( $url ) {
-	$dir = str_replace( get_option( 'home' ), '', $url );
-	if ( $dir != '' ) {
-		$supercachedir = get_supercache_dir();
-		wpsc_delete_files( $supercachedir . $dir );
-		prune_super_cache( $supercachedir . $dir . '/page', true );
-		return true;
-	} else {
-		return false;
-	}
-}
-
 function wpsc_delete_post_cache( $id ) {
 	$post = get_post( $id );
 	wpsc_delete_url_cache( get_author_posts_url( $post->post_author ) );


### PR DESCRIPTION
If a user activates the plugin on one blog of a multisite to admin other
blogs then wp-cache.php won't be loaded on those other blogs.