### PR TITLE
If wpsc_deep_replace() is missing then stop with an error message.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -486,6 +486,13 @@ function wp_cache_manager_updates() {
 	if ( $valid_nonce == false )
 		return false;
 
+	if ( false == function_exists( 'wpsc_deep_replace' ) ) {
+		$msg = __( 'Warning! You must set WP_CACHE and WPCACHEHOME in your wp-config.php for this plugin to work correctly:' ) . '<br />';
+		$msg .= "<code>define( 'WP_CACHE', true );</code><br />";
+		$msg .= "<code>define( 'WPCACHEHOME', '" . dirname( __FILE__ ) . "' );</code><br />";
+		wp_die( $msg );
+	}
+
 	if ( isset( $_POST[ 'action' ] ) && $_POST[ 'action' ] == 'easysetup' ) {
 		$_POST[ 'action' ] = 'scupdates';
 		if( isset( $_POST[ 'wp_cache_easy_on' ] ) && $_POST[ 'wp_cache_easy_on' ] == 1 ) {


### PR DESCRIPTION
Fixes #75
Some users have unusual server configurations that means
advanced-cache.php and wp-cache-phase1.php aren't loaded when the
WordPress dashboard is running. This code exits with an error message if
that happens because the advanced settings page cannot save any updates.