### PR TITLE
Improve PHP 7.0 compatibility

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -42,11 +42,10 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 				$settings[ $name ] = get_option( $map['option'] );
 
 			} elseif ( isset( $map['global'] ) ) {
-				$global_var = $map['global'];
-				if ( false == isset( $$global_var ) ) {
+				if ( false == isset( $GLOBALS[ $map[ 'global' ] ] ) ) {
 					$settings[ $name ] = false;
 				} else {
-					$settings[ $name ] = $$global_var;
+					$settings[ $name ] = $GLOBALS[ $map[ 'global' ] ];
 				}
 			}
 		}

--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -502,9 +502,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 		);
 
 		foreach ( $advanced_settings as $setting ) {
-			global ${$setting};
-
-			$value = ( isset( $$setting ) && $$setting == 1 ) ? 1 : 0;
+			$value = ( isset( $GLOBALS[ $setting ] ) && $GLOBALS[ $setting ] == 1 ) ? 1 : 0;
 			$this->set_value_by_key( $value, $setting );
 		}
 	}
@@ -529,9 +527,8 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 		);
 
 		foreach ( $all_time_settings as $time_setting ) {
-			global ${$time_setting};
-			if ( false == isset( $_POST[ $time_setting ] ) || $$time_setting == $_POST[ $time_setting ] ) {
-				$_POST[ $time_setting ] = $$time_setting; // fill in the potentially missing fields before updating GC settings.
+			if ( false == isset( $_POST[ $time_setting ] ) || $GLOBALS[ $time_setting ] == $_POST[ $time_setting ] ) {
+				$_POST[ $time_setting ] = $GLOBALS[ $time_setting ]; // fill in the potentially missing fields before updating GC settings.
 			}
 		}
 
@@ -590,8 +587,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 
 		foreach ( $all_preload_settings as $key => $original ) {
 			if ( ! isset( $_POST[ $key ] ) ) {
-				global ${$original};
-				$_POST[ $original ] = $$original;
+				$_POST[ $original ] = $GLOBALS[ $original ];
 			} else {
 				$_POST[ $original ] = $_POST[ $key ];
 				if ( $key !== 'preload_interval' && ( $_POST[ $key ] === 0 || $_POST[ $key ] === false ) ) {
@@ -649,8 +645,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 				}
 				$_POST[ 'wp_cache_debug' ] = 1;
 			} else {
-				global $$setting;
-				$_POST[ $setting ] = $$setting;
+				$_POST[ $setting ] = $GLOBALS[ $setting ];
 			}
 		}
 		global $valid_nonce;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -518,7 +518,7 @@ function wp_cache_manager_updates() {
 		}
 		$advanced_settings = array( 'wp_super_cache_late_init', 'wp_cache_disable_utf8', 'wp_cache_no_cache_for_get', 'wp_supercache_304', 'wp_cache_mfunc_enabled', 'wp_cache_mobile_enabled', 'wp_cache_front_page_checks', 'wp_supercache_cache_list', 'wp_cache_hello_world', 'wp_cache_clear_on_post_edit', 'wp_cache_not_logged_in', 'wp_cache_make_known_anon','wp_cache_object_cache', 'wp_cache_refresh_single_only', 'cache_compression' );
 		foreach( $advanced_settings as $setting ) {
-			if ( isset( $$setting ) && $$setting == 1 ) {
+			if ( isset( $GLOBALS[ $setting ] ) && $GLOBALS[ $setting ] == 1 ) {
 				$_POST[ $setting ] = 1;
 			}
 		}
@@ -2155,8 +2155,8 @@ function wp_cache_is_enabled() {
 
 function wp_cache_setting( $field, $value ) {
 	global $wp_cache_config_file;
-	global ${$field};
-	$$field = $value;
+
+	$GLOBALS[ $field ] = $value;
 	if ( is_numeric( $value ) ) {
 		wp_cache_replace_line( '^ *\$' . $field, "\$$field = $value;", $wp_cache_config_file );
 	} elseif ( is_object( $value ) || is_array( $value ) ) {
@@ -3984,8 +3984,7 @@ function wpsc_get_plugin_list() {
 	$list = do_cacheaction( 'wpsc_filter_list' );
 	foreach( $list as $t => $details ) {
 		$key = "cache_" . $details[ 'key' ];
-		global $$key;
-		if ( isset( $$key ) && $$key == 1 ) {
+		if ( isset( $GLOBALS[ $key ] ) && $GLOBALS[ $key ] == 1 ) {
 			$list[ $t ][ 'enabled' ] = true;
 		} else {
 			$list[ $t ][ 'enabled' ] = false;
@@ -4001,8 +4000,7 @@ function wpsc_update_plugin_list( $update ) {
 	$list = do_cacheaction( 'wpsc_filter_list' );
 	foreach( $update as $key => $enabled ) {
 		$plugin_toggle = "cache_{$key}";
-		global $$plugin_toggle;
-		if ( isset( $$plugin_toggle ) || isset( $list[ $key ] ) ) {
+		if ( isset( $GLOBALS[ $plugin_toggle ] ) || isset( $list[ $key ] ) ) {
 			wp_cache_setting( $plugin_toggle, (int)$enabled );
 		}
 	}


### PR DESCRIPTION
* Replace _[variable variables](http://php.net/manual/en/language.variables.variable.php)_ with _[$GLOBALS](http://php.net/manual/en/reserved.variables.globals.php)_. Code is more readable.

Related issues:
https://wordpress.org/support/topic/is-this-plugin-php7-compatible-2/
https://wordpress.org/support/topic/wp-super-cache-compatibility-with-php-7/
https://wordpress.org/support/topic/warnings-and-errors-in-compatibility-with-php7/