### PR TITLE
Register hook in is_admin() to avoid unnecessary queries. props @krzyc.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -151,7 +151,9 @@ function wpsupercache_uninstall() {
 	wp_cache_disable_plugin();
 	delete_site_option( 'wp_super_cache_index_detected' );
 }
-register_uninstall_hook( __FILE__, 'wpsupercache_uninstall' );
+if ( is_admin() ) {
+	register_uninstall_hook( __FILE__, 'wpsupercache_uninstall' );
+}
 
 function wpsupercache_deactivate() {
 	global $wp_cache_config_file, $wp_cache_link, $cache_path;


### PR DESCRIPTION
ref:
https://wordpress.org/support/topic/register_uninstall_hook-should-only-be-called-when-is_admin-is-true/