### PR TITLE
Check that needle is not empty before searching for it.

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -34,8 +34,8 @@ if ($arr_of_cnames[0] == '') $arr_of_cnames = array();
  * @return Boolean true if to exclude given match from rewriting
  */
 function scossdl_off_exclude_match($match, $excludes) {
-	foreach ($excludes as $badword) {
-		if (stristr($match, $badword) != false) {
+	foreach( $excludes as $badword ) {
+		if ( ! empty( $badword ) && stripos( $match, $badword ) !== false ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
If the CDN setting "Exclude if substring" is blank a warning will be
generated when you look for it. This fixes that and uses stripos instead
of stristr as it's faster.
ref: https://wordpress.org/support/topic/another-empty-needle-issue/