### PR TITLE
 Move wp_cache_setting to phase1 file, and load everything on activation

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -1067,6 +1067,30 @@ function wpsc_delete_url_cache( $url ) {
 	}
 }
 
+// from legolas558 d0t users dot sf dot net at http://www.php.net/is_writable
+function is_writeable_ACLSafe( $path ) {
+
+	// PHP's is_writable does not work with Win32 NTFS
+
+	if ( $path[ strlen( $path ) - 1 ] == '/' ) { // recursively return a temporary file path
+		return is_writeable_ACLSafe( $path . uniqid( mt_rand() ) . '.tmp' );
+	} elseif ( is_dir( $path ) ) {
+		return is_writeable_ACLSafe( $path . '/' . uniqid( mt_rand() ) . '.tmp' );
+	}
+
+	// check tmp file for read/write capabilities
+	$rm = file_exists( $path );
+	$f = @fopen( $path, 'a' );
+	if ( $f === false )
+		return false;
+	fclose( $f );
+	if ( ! $rm ) {
+		unlink( $path );
+	}
+
+	return true;
+}
+
 function wp_cache_setting( $field, $value ) {
 	global $wp_cache_config_file;
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -91,26 +91,6 @@ add_action( 'template_redirect', 'wp_cache_set_home' );
 // OSSDL CDN plugin (https://wordpress.org/plugins/ossdl-cdn-off-linker/)
 include_once( WPCACHEHOME . 'ossdl-cdn.php' );
 
-// from legolas558 d0t users dot sf dot net at http://www.php.net/is_writable
-function is_writeable_ACLSafe($path) {
-
-	// PHP's is_writable does not work with Win32 NTFS
-
-	if ($path{strlen($path)-1}=='/') // recursively return a temporary file path
-		return is_writeable_ACLSafe($path.uniqid(mt_rand()).'.tmp');
-	else if (is_dir($path))
-		return is_writeable_ACLSafe($path.'/'.uniqid(mt_rand()).'.tmp');
-	// check tmp file for read/write capabilities
-	$rm = file_exists($path);
-	$f = @fopen($path, 'a');
-	if ($f===false)
-		return false;
-	fclose($f);
-	if (!$rm)
-		unlink($path);
-	return true;
-}
-
 function get_wpcachehome() {
 	if( defined( 'WPCACHEHOME' ) == false ) {
 		if( is_file( dirname(__FILE__) . '/wp-cache-config-sample.php' ) ) {


### PR DESCRIPTION
The function wp_cache_setting() is used by the debug logger in
wp-cache-phase1.php so we need to define that function earlier.
The activation script then has to include the phase1 script so the
plugin can record settings.

Move is_writeable_ACLSafe to phase1 too as it's used there.