### PR TITLE
Change Tested up to and add Requires PHP

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 # WP Super Cache #
 * Contributors: donncha, automattic, kraftbj
 * Tags: performance, caching, wp-cache, wp-super-cache, cache
-* Tested up to: 4.9
+* Tested up to: 4.9.1
 * Stable tag: 1.5.8
 * Requires at least: 3.0
+* Requires PHP: 5.2.4
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
* Change `Tested up to` 4.9.1
* Add  `Requires PHP`.  Related info:
https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/
https://core.trac.wordpress.org/ticket/40934

Readme.txt is checked by https://wordpress.org/plugins/developers/readme-validator/