### PR TITLE
Little cleanup 1

### DIFF
--- a/plugins/awaitingmoderation.php
+++ b/plugins/awaitingmoderation.php
@@ -63,4 +63,3 @@ function wpsc_awaiting_moderation_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_awaiting_moderation_list' );
-?>

--- a/plugins/badbehaviour.php
+++ b/plugins/badbehaviour.php
@@ -101,5 +101,3 @@ function wpsc_badbehaviour_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_badbehaviour_list' );
-
-?>

--- a/plugins/domain-mapping.php
+++ b/plugins/domain-mapping.php
@@ -130,5 +130,3 @@ function wpsc_domain_mapping_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_domain_mapping_list' );
-
-?>

--- a/plugins/dynamic-cache-test.php
+++ b/plugins/dynamic-cache-test.php
@@ -186,4 +186,3 @@ if ( '' !== DYNAMIC_OUTPUT_BUFFER_TAG ) {
 	}
 	add_cacheaction( 'wpsc_cachedata_safety', 'dynamic_output_buffer_test_safety' );
 }
-?>

--- a/plugins/jetpack.php
+++ b/plugins/jetpack.php
@@ -89,5 +89,3 @@ function wpsc_cache_jetpack_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_cache_jetpack_list' );
-
-?>

--- a/plugins/multisite.php
+++ b/plugins/multisite.php
@@ -20,11 +20,13 @@ function wp_super_cache_blogs_field( $name, $blog_id ) {
 		return false;
 	}
 
-	if ( isset( $_GET['id'] ) && $blog_id === $_GET['id'] ) {
-		$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'wp-cache' . $_GET['id'] ) : false;
-		if ( $valid_nonce && isset( $_GET['action'] ) && 'disable_cache' === $_GET['action'] ) {
+	if ( isset( $_GET['id'], $_GET['action'], $_GET['_wpnonce'] )
+		&& $blog_id === intval( $_GET['id'] )
+		&& wp_verify_nonce( $_GET['_wpnonce'], 'wp-cache' . $blog_id )
+	) {
+		if ( 'disable_cache' === $_GET['action'] ) {
 			add_blog_option( $_GET['id'], 'wp_super_cache_disabled', 1 );
-		} elseif ( $valid_nonce && isset( $_GET['action'] ) && 'enable_cache' ===  $_GET['action'] ) {
+		} elseif ( 'enable_cache' ===  $_GET['action'] ) {
 			delete_blog_option( $_GET['id'], 'wp_super_cache_disabled' );
 		}
 	}
@@ -58,5 +60,3 @@ function wp_super_cache_override_on_flag() {
 		}
 	}
 }
-
-?>

--- a/plugins/searchengine.php
+++ b/plugins/searchengine.php
@@ -1,19 +1,16 @@
 <?php
+
 function wp_supercache_searchengine( $string ) {
 	global $passingthrough, $nevershowads, $cache_no_adverts_for_friends;
 
 	$cache_no_adverts_for_friends = wpsc_get_searchengine_setting();
-	if ( ! $cache_no_adverts_for_friends ) {
-		return $string;
-	}
-
-	if ( '' !== $string ) {
+	if ( ! $cache_no_adverts_for_friends || empty( $string) ) {
 		return $string;
 	}
 
 	if ( isset( $_COOKIE['7a1254cba80da02d5478d91cfd0a873a'] ) && '1' === $_COOKIE['7a1254cba80da02d5478d91cfd0a873a'] ) {
 		$string = 'searchengine';
-	} elseif ( isset( $_SERVER['HTTP_REFERER'] ) && '' !== $_SERVER['HTTP_REFERER'] ) {
+	} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
 		if ( is_array( $passingthrough ) === false ) {
 			return $string;
 		}
@@ -129,5 +126,3 @@ function wpsc_cache_no_adverts_for_friends_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_cache_no_adverts_for_friends_list' );
-
-?>

--- a/plugins/searchengine.php
+++ b/plugins/searchengine.php
@@ -4,7 +4,7 @@ function wp_supercache_searchengine( $string ) {
 	global $passingthrough, $nevershowads, $cache_no_adverts_for_friends;
 
 	$cache_no_adverts_for_friends = wpsc_get_searchengine_setting();
-	if ( ! $cache_no_adverts_for_friends || empty( $string) ) {
+	if ( ! $cache_no_adverts_for_friends || '' != $string ) {
 		return $string;
 	}
 

--- a/plugins/wptouch.php
+++ b/plugins/wptouch.php
@@ -141,5 +141,3 @@ function wpsc_wptouch_list( $list ) {
 	return $list;
 }
 add_cacheaction( 'wpsc_filter_list', 'wpsc_wptouch_list' );
-
-?>


### PR DESCRIPTION
* Fix white spaces/docblock after last few PRs.
* Fix some names, remove unused global variables ( _ossdl-cdn.php_ ).
* Remove php closing tag from the end of plugins files ( _awaitingmoderation.php_,  _dynamic-cache-test.php_,  _searchengine.php_, _badbehaviour.php_, _jetpack.php_, _domain-mapping.php_, _multisite.php_, _wptouch.php_ ).
* Remove `else` to reduce complexity (recommend by phpmd and codeclimate).
* Improve conditionals for checking _wpnonce_.

Checked by [phpmd](https://phpmd.org/).