### PR TITLE
Fix issues in multisite plugin

### DIFF
--- a/plugins/multisite.php
+++ b/plugins/multisite.php
@@ -20,18 +20,20 @@ function wp_super_cache_blogs_field( $name, $blog_id ) {
 		return false;
 	}
 
+	$blog_id = (int) $blog_id;
+
 	if ( isset( $_GET['id'], $_GET['action'], $_GET['_wpnonce'] )
-		&& $blog_id === intval( $_GET['id'] )
+		&& $blog_id === filter_input( INPUT_GET, 'id', FILTER_VALIDATE_INT )
 		&& wp_verify_nonce( $_GET['_wpnonce'], 'wp-cache' . $blog_id )
 	) {
-		if ( 'disable_cache' === $_GET['action'] ) {
-			add_blog_option( $_GET['id'], 'wp_super_cache_disabled', 1 );
-		} elseif ( 'enable_cache' ===  $_GET['action'] ) {
-			delete_blog_option( $_GET['id'], 'wp_super_cache_disabled' );
+		if ( 'disable_cache' === filter_input( INPUT_GET, 'action' ) ) {
+			add_blog_option( $blog_id, 'wp_super_cache_disabled', 1 );
+		} elseif ( 'enable_cache' === filter_input( INPUT_GET, 'action' ) ) {
+			delete_blog_option( $blog_id, 'wp_super_cache_disabled' );
 		}
 	}
 
-	if ( get_blog_option( $blog_id, 'wp_super_cache_disabled' ) === 1 ) {
+	if ( 1 === (int) get_blog_option( $blog_id, 'wp_super_cache_disabled' ) ) {
 		echo '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'enable_cache', 'id' => $blog_id ) ), 'wp-cache' . $blog_id ) . '">' . __( 'Enable', 'wp-super-cache' ) . '</a>';
 	} else {
 		echo '<a href="' . wp_nonce_url( add_query_arg( array( 'action' => 'disable_cache', 'id' => $blog_id ) ), 'wp-cache' . $blog_id ) . '">' . __( 'Disable', 'wp-super-cache' ) . '</a>';
@@ -39,7 +41,7 @@ function wp_super_cache_blogs_field( $name, $blog_id ) {
 }
 
 function wp_super_cache_multisite_notice() {
-	if ( isset( $_GET['page'] ) && 'wpsupercache' === $_GET['page'] ) {
+	if ( 'wpsupercache' === filter_input( INPUT_GET, 'page' ) ) {
 		echo '<div class="error"><p><strong>' . __( 'Caching has been disabled on this blog on the Network Admin Sites page.', 'wp-super-cache' ) . '</strong></p></div>';
 	}
 }
@@ -50,7 +52,7 @@ function wp_super_cache_override_on_flag() {
 		return false;
 	}
 
-	if ( get_option( 'wp_super_cache_disabled' ) ) {
+	if ( 1 === (int) get_option( 'wp_super_cache_disabled' ) ) {
 		$cache_enabled = false;
 		$super_cache_enabled = false;
 		define( 'DONOTCACHEPAGE', 1 );


### PR DESCRIPTION
* Cast `$blog_id` as int.
* Add [filter_input](http://php.net/manual/en/function.filter-input.php) for better security.

This PR fixes issue related to enable/disable caching in Network Admin/Sites, `$blog_id` is string in many cases regardless to https://developer.wordpress.org/reference/hooks/manage_sites_custom_column/