### PR TITLE
display correct WPCACHEHOME path in error messages

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -281,7 +281,7 @@ function wp_cache_manager_error_checks() {
 	if ( false == function_exists( 'wpsc_deep_replace' ) ) {
 		$msg = __( 'Warning! You must set WP_CACHE and WPCACHEHOME in your wp-config.php for this plugin to work correctly:' ) . '<br />';
 		$msg .= "<code>define( 'WP_CACHE', true );</code><br />";
-		$msg .= "<code>define( 'WPCACHEHOME', '" . dirname( __FILE__ ) . "' );</code><br />";
+		$msg .= "<code>define( 'WPCACHEHOME', '" . dirname( __FILE__ ) . "/' );</code><br />";
 		wp_die( $msg );
 	}
 


### PR DESCRIPTION
It took me some time to figure out what was wrong, although I followed the on screen instructions.

There is just a trailing slash missing but it might help configuring this plugin correctly.