### PR TITLE
Add check for Jetpack mobile theme cookie

### DIFF
--- a/plugins/jetpack.php
+++ b/plugins/jetpack.php
@@ -64,6 +64,14 @@ function wp_super_cache_jetpack_cookie_check( $cache_key ) {
 		}
 	}
 
+	if ( isset ( $_COOKIE['akm_mobile'] ) ) {
+		if ( $_COOKIE['akm_mobile'] == 'true' ) {
+			return 'mobile';
+		} elseif ( $_COOKIE['akm_mobile'] == 'false' ) {
+			return 'normal';
+		}
+	}
+
 	if ( function_exists( 'jetpack_is_mobile' ) ) {
 		if ( jetpack_is_mobile() ) {
 			return 'mobile';


### PR DESCRIPTION
The Jetpack mobile theme plugin for Super Cache uses Jetpack's `jetpack_is_mobile()` function to determine whether to serve and cache the desktop or mobile version of the page. However, the actual Minileven theme uses a function called `jetpack_check_mobile()` which adds a few additional checks (see [here](https://github.com/Automattic/jetpack/blob/master/modules/minileven/minileven.php)). I believe these can largely be ignored for the purposes of the cache, and certainly attempting to replace calls to `jetpack_is_mobile()` with calls to `jetpack_check_mobile()` fail.

However, the `akm_mobile` cookie does affect the cached variant, and if it's not checked it will serve incorrect pages to users who've specifically requested the mobile/desktop version of the site (using the link at the bottom of the page). If the page is uncached at request time, it will also be cached wrong and served incorrectly to all subsequent users until the cache expires.

Add a check for the cookie before checking `jetpack_is_mobile()`. This has been live on my site for the last couple of weeks and appears to have fixed issues we were having with occasional incorrect cached pages.