### PR TITLE
Post Update now clears category cache

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2587,7 +2587,7 @@ function wpsc_post_transition( $new_status, $old_status, $post ) {
 	if (
 		($old_status == 'publish' && $new_status != 'publish' ) // post unpublished
 		||
-		($old_status != 'publish' && $new_status == 'publish') // post published
+		($new_status == 'publish') // post published or updated
 	) {
 		//wpsc_delete_cats_tags( $post );
 		wpsc_delete_post_archives( $post );


### PR DESCRIPTION
If a post was updated, it would clear the homepage and post cache, but the category pages wouldn't clear.
> category/stories/...

The function was set to only update categories when a post was changed from un-published to published or vice versa.
It's been changed so it clears the category cache when a post goes from un-published to published or a change is made when it's published.