### PR TITLE
fix: amp url serves cached canonical page

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3246,7 +3246,7 @@ function wpsc_get_htaccess_info() {
 		$condition_rules[] = "RewriteCond %{REQUEST_URI} !^.*//.*$";
 	}
 	$condition_rules[] = "RewriteCond %{REQUEST_METHOD} !POST";
-	$condition_rules[] = "RewriteCond %{QUERY_STRING} !.*=.*";
+	$condition_rules[] = "RewriteCond %{QUERY_STRING} ^$";
 	$condition_rules[] = "RewriteCond %{HTTP:Cookie} !^.*(comment_author_|" . wpsc_get_logged_in_cookie() . "|wp-postpass_).*$";
 	$condition_rules[] = "RewriteCond %{HTTP:X-Wap-Profile} !^[a-z0-9\\\"]+ [NC]";
 	$condition_rules[] = "RewriteCond %{HTTP:Profile} !^[a-z0-9\\\"]+ [NC]";


### PR DESCRIPTION
the AMP plugin creates urls with ?amp as GET parameters, but they don't get served in Expert mode caching with "don't serve cached page with get parameters".
This is because the RewriteCond says `%{QUERY_STRING} !.*=.*` which translates to "there must be an equals sign in the query string.
With ?amp there is no equals sign, so instead of an AMP page, the original page is shown.

This pull requests suggests a proper fix for this condition.

There is an alternative, namely testing for `!.*=.*` AND `!amp` but since the PHP version checks empty($_GET), there should not be anything in then Query string, hence `^$` for "blank".