### PR TITLE
adding hook for full cache purges

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2094,10 +2094,10 @@ function wp_cache_phase2_clean_cache($file_prefix) {
 						@unlink( $blog_cache_dir . 'meta/' . $file );
 					}
 				}
-				do_action('wp_cache_cleared');
 			}
 		}
 		closedir($handle);
+                do_action('wp_cache_cleared');
 	}
 	wp_cache_writers_exit();
 }

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2094,6 +2094,7 @@ function wp_cache_phase2_clean_cache($file_prefix) {
 						@unlink( $blog_cache_dir . 'meta/' . $file );
 					}
 				}
+				do_action('wp_cache_cleared');
 			}
 		}
 		closedir($handle);
@@ -2533,6 +2534,7 @@ function wp_cache_clear_cache( $blog_id = 0 ) {
 			prune_super_cache( $cache_path . 'blogs/', true );
 		}
 	}
+	do_action('wp_cache_cleared');
 }
 
 function wpsc_delete_post_archives( $post ) {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2880,6 +2880,8 @@ function wpsc_dirsize($directory, $sizes) {
 function wp_cache_clean_cache( $file_prefix, $all = false ) {
 	global $cache_path, $supercachedir, $blog_cache_dir, $wp_cache_object_cache;
 
+	do_action('wp_cache_cleared');
+
 	if ( $wp_cache_object_cache && function_exists( "reset_oc_version" ) )
 		reset_oc_version();
 


### PR DESCRIPTION
Goal: allow other plugins to hook into WP Super Cache's clearing the cache entirely by adding a do_action

Reason: in my case I want to purge Autoptimize's cache when WP SC's is fully cleared. 

cfr. https://github.com/Automattic/wp-super-cache/issues/903

Will be happy to improve when/ if needed.