### PR TITLE
Hide opcache_invalidate() warnings since it's disabled in some places.

### DIFF
--- a/rest/class.wp-super-cache-rest-get-settings.php
+++ b/rest/class.wp-super-cache-rest-get-settings.php
@@ -23,7 +23,7 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 		}
 
 		if ( function_exists( "opcache_invalidate" ) ) {
-			opcache_invalidate( $wp_cache_config_file );
+			@opcache_invalidate( $wp_cache_config_file );
 		}
 		include( $wp_cache_config_file );
 
@@ -78,7 +78,7 @@ class WP_Super_Cache_Rest_Get_Settings extends WP_REST_Controller {
 	public function get_cache_type() {
 		global $wp_cache_config_file;
 		if ( function_exists( "opcache_invalidate" ) ) {
-			opcache_invalidate( $wp_cache_config_file );
+			@opcache_invalidate( $wp_cache_config_file );
 		}
 		include( $wp_cache_config_file );
 

--- a/rest/class.wp-super-cache-rest-update-settings.php
+++ b/rest/class.wp-super-cache-rest-update-settings.php
@@ -608,7 +608,7 @@ class WP_Super_Cache_Rest_Update_Settings extends WP_REST_Controller {
 			wp_cache_setting( 'cache_page_secret', $cache_page_secret );
 
 			if ( function_exists( "opcache_invalidate" ) ) {
-				opcache_invalidate( $wp_cache_config_file );
+				@opcache_invalidate( $wp_cache_config_file );
 			}
 		}
 		wpsc_set_default_gc( true );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1106,7 +1106,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	@rename( $tmp_file, $my_file );
 
 	if ( function_exists( "opcache_invalidate" ) ) {
-		opcache_invalidate( $my_file );
+		@opcache_invalidate( $my_file );
 	}
 
 	return true;


### PR DESCRIPTION
Fixes #536
Those hosts may run into problems with the REST API since the config
file will be reloaded with old settings.