### PR TITLE
Add a notice when settings can't be updated.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1046,10 +1046,18 @@ function wp_cache_setting( $field, $value ) {
 
 function wp_cache_replace_line( $old, $new, $my_file ) {
 	if ( @is_file( $my_file ) == false ) {
+		set_transient( 'wpsc_config_error', 'config_file_missing', 10 );
 		return false;
 	}
 	if (!is_writeable_ACLSafe($my_file)) {
+		set_transient( 'wpsc_config_error', 'config_file_ro', 10 );
 		trigger_error( "Error: file $my_file is not writable." );
+		return false;
+	}
+	$tmp_file = dirname( $my_file ) . '/' . mt_rand() . '.php';
+	if ( ! is_writeable_ACLSafe( $tmp_file ) ) {
+		set_transient( 'wpsc_config_error', 'tmp_file_ro', 10 );
+		trigger_error( "Error: temporary file $tmp_file is not writable. Make sure directory is writeable." );
 		return false;
 	}
 
@@ -1064,6 +1072,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		} else {
 			$c++;
 			if ( $c > 100 ) {
+				set_transient( 'wpsc_config_error', 'config_file_not_loaded', 10 );
 				trigger_error( "wp_cache_replace_line: Error  - file $my_file could not be loaded." );
 				return false;
 			}
@@ -1076,9 +1085,9 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 
-	$tmp_file = dirname( $my_file ) . '/' . mt_rand() . '.php';
 	$fd = fopen( $tmp_file, 'w' );
 	if ( ! $fd ) {
+		set_transient( 'wpsc_config_error', 'config_file_ro', 10 );
 		trigger_error( "wp_cache_replace_line: Error  - could not write to $tmp_file" );
 		return false;
 	}

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2292,6 +2292,34 @@ function wp_cache_index_notice() {
 }
 add_action( 'admin_notices', 'wp_cache_index_notice' );
 
+function wpsc_config_file_notices() {
+	global $wp_cache_config_file;
+	if ( ! isset( $_GET['page'] ) || $_GET['page'] != 'wpsupercache' ) {
+		return false;
+	}
+	$notice = get_transient( 'wpsc_config_error' );
+	if ( ! $notice ) {
+		return false;
+	}
+	switch( $notice ) {
+		case 'config_file_ro':
+			$msg = sprintf( __( 'Error: Configuration file is read only. Please make sure %s is writeable by the webserver.' ), $wp_cache_config_file );
+			break;
+		case 'tmp_file_ro':
+			$msg = sprintf( __( 'Error: The directory containing the configuration file %s is read only. Please make sure it is writeable by the webserver.' ), $wp_cache_config_file );
+			break;
+		case 'config_file_not_loaded':
+			$msg = sprintf( __( 'Error: Configuration file %s could not be loaded. Please reload the page.' ), $wp_cache_config_file );
+			break;
+		case 'config_file_missing':
+			$msg = sprintf( __( 'Error: Configuration file %s s missing. Please reload the page.' ), $wp_cache_config_file );
+			break;
+
+	}
+	echo '<div class="error"><p><strong>' . $msg . '</strong></p></div>';
+}
+add_action( 'admin_notices', 'wpsc_config_file_notices' );
+
 function wpsc_dismiss_indexhtml_warning() {
 		check_ajax_referer( "wpsc-index-dismiss" );
 		update_site_option( 'wp_super_cache_index_detected', 3 );


### PR DESCRIPTION
Fixes #535 #550
The plugin would silently fail to update options since it writes to a
temporary file before copying over the config file. The config file is
writeable but the plugin won't have permission to create a new file if
the holding directory (usually wp-content) is not writeable.