### PR TITLE
Fix/avoid serving expired file

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -104,6 +104,7 @@ function wp_cache_serve_cache_file() {
 		}
 	} else { // no $cache_file
 		global $wpsc_save_headers;
+		global $cache_max_time;
 		// last chance, check if a supercache file exists. Just in case .htaccess rules don't work on this host
 		$filename = supercache_filename();
 		$file = get_current_url_supercache_dir() . $filename;
@@ -119,7 +120,10 @@ function wp_cache_serve_cache_file() {
 		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
 			wp_cache_debug( 'Saving headers. Cannot serve a supercache file.' );
 			return false;
-		}
+		}elseif ( (filemtime( $file ) + $cache_max_time) < time() ) {
+            wp_cache_debug( sprintf( "Cache has expired and is older than %d seconds old.", $cache_max_time ) );
+            return false;
+    }
 
 		if ( isset( $wp_cache_mfunc_enabled ) == false )
 			$wp_cache_mfunc_enabled = 0;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -120,7 +120,7 @@ function wp_cache_serve_cache_file() {
 		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
 			wp_cache_debug( 'Saving headers. Cannot serve a supercache file.' );
 			return false;
-		}elseif ( (filemtime( $file ) + $cache_max_time) < time() ) {
+		} elseif ( (filemtime( $file ) + $cache_max_time) < time() ) {
             wp_cache_debug( sprintf( "Cache has expired and is older than %d seconds old.", $cache_max_time ) );
             return false;
     }

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -120,10 +120,10 @@ function wp_cache_serve_cache_file() {
 		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
 			wp_cache_debug( 'Saving headers. Cannot serve a supercache file.' );
 			return false;
-		} elseif ( (filemtime( $file ) + $cache_max_time) < time() ) {
-            wp_cache_debug( sprintf( "Cache has expired and is older than %d seconds old.", $cache_max_time ) );
-            return false;
-    }
+		} elseif ( ( filemtime( $file ) + $cache_max_time ) < time() ) {
+			wp_cache_debug( sprintf( "Cache has expired and is older than %d seconds old.", $cache_max_time ) );
+			return false;
+		}
 
 		if ( isset( $wp_cache_mfunc_enabled ) == false )
 			$wp_cache_mfunc_enabled = 0;


### PR DESCRIPTION
I noticed this issue when the cache is served directly from the file. So all I added was a check to compare the file creation time + $cache_max_time against current time.

If expired, we return false and new cache is generated.

Notes:
- I came across this issue when storing cache files in a custom directory. E.g: `/tmp/wp-super-cache`
- I tested it locally and it worked as expected.
