### PR TITLE
Only check the cache max time if it's not 0, and GC disabled.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -120,7 +120,7 @@ function wp_cache_serve_cache_file() {
 		} elseif ( isset( $wpsc_save_headers ) && $wpsc_save_headers ) {
 			wp_cache_debug( 'Saving headers. Cannot serve a supercache file.' );
 			return false;
-		} elseif ( ( filemtime( $file ) + $cache_max_time ) < time() ) {
+		} elseif ( $cache_max_time > 0 && ( filemtime( $file ) + $cache_max_time ) < time() ) {
 			wp_cache_debug( sprintf( "Cache has expired and is older than %d seconds old.", $cache_max_time ) );
 			return false;
 		}


### PR DESCRIPTION
By setting the cache max time to 0 garbage collection is disabled but
this test would stop PHP serving cache files because it detected that
they were expired.
Fixes https://wordpress.org/support/topic/version-1-6-2-fails-to-cache-had-to-revert-to-1-6-1/