### PR TITLE
Don't clean expired files when GC is disabled.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2325,6 +2325,11 @@ function wp_cache_rebuild_or_delete( $file ) {
 function wp_cache_phase2_clean_expired( $file_prefix, $force = false ) {
 	global $cache_path, $cache_max_time, $blog_cache_dir, $wp_cache_preload_on;
 
+	if ( $cache_max_time == 0 ) {
+		wp_cache_debug( "wp_cache_phase2_clean_expired: disabled because GC disabled.", 2 );
+		return false;
+	}
+
 	clearstatcache();
 	if( !wp_cache_writers_entry() )
 		return false;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3562,8 +3562,10 @@ function wp_cron_preload_cache() {
 		}
 		if ( $wp_cache_preload_email_me )
 			wp_mail( get_option( 'admin_email' ), sprintf( __( '[%s] Cache Preload Completed', 'wp-super-cache' ), home_url() ), __( "Cleaning up old supercache files.", 'wp-super-cache' ) . "\n" . $msg );
-		wp_cache_debug( "wp_cron_preload_cache: clean expired cache files older than $cache_max_time seconds.", 5 );
-		wp_cache_phase2_clean_expired( $file_prefix, true ); // force cleanup of old files.
+		if ( $cache_max_time > 0 ) { // GC is NOT disabled
+			wp_cache_debug( "wp_cron_preload_cache: clean expired cache files older than $cache_max_time seconds.", 5 );
+			wp_cache_phase2_clean_expired( $file_prefix, true ); // force cleanup of old files.
+		}
 	}
 	@unlink( $mutex );
 }


### PR DESCRIPTION
This hopefully fixes the problems where cache files are deleted after
preload:
https://wordpress.org/support/topic/preload-cache-doesnt-seem-to-preload-all-pages/
https://wordpress.org/support/topic/issue-with-preloading/