### PR TITLE
Improve deleting of cache in edit/delete/publish actions - rev

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2667,6 +2667,10 @@ function wpsc_delete_post_archives( $post ) {
 }
 
 function wpsc_delete_cats_tags( $post ) {
+	if ( function_exists( '_deprecated_function' ) ) {
+		_deprecated_function( __FUNCTION__, 'WP Super Cache 1.6.3', 'wpsc_delete_post_archives' );
+	}
+
 	$post = get_post($post);
 	$categories = get_the_category($post->ID);
 	if ( $categories ) {
@@ -2693,14 +2697,17 @@ function wpsc_delete_cats_tags( $post ) {
 }
 
 function wpsc_post_transition( $new_status, $old_status, $post ) {
-	if (
-		($old_status == 'publish' && $new_status != 'publish' ) // post unpublished
-		||
-		($new_status == 'publish') // post published or updated
-	) {
-		//wpsc_delete_cats_tags( $post );
+
+	if ( $old_status === 'publish' && $new_status !== 'publish' ) { // post unpublished
+		list( $permalink, $post_name ) = get_sample_permalink( $post->ID );
+		$post_url = str_replace( array( '%pagename%', '%postname%' ), $post->post_name, $permalink );
+	}
+	elseif ( $new_status === 'publish' )  {	// post published or updated
+		$post_url  = get_permalink( $post->ID );
+	}
+
+	if ( ! empty( $post_url ) ) {
 		wpsc_delete_post_archives( $post );
-		$post_url = get_permalink( $post->ID );
 		wpsc_delete_url_cache( $post_url );
 		wp_cache_debug( 'wpsc_post_transition: deleting cache of post: ' . $post_url );
 	}
@@ -2740,6 +2747,7 @@ function wp_cache_post_edit($post_id) {
 	} else {
 		wp_cache_debug( "wp_cache_post_edit: Clearing cache for post $post_id on post edit.", 2 );
 		wp_cache_post_change( $post_id );
+		wpsc_delete_post_archives( $post_id ); // delete related archive pages.
 	}
 }
 


### PR DESCRIPTION
* Use [get_sample_permalink](https://developer.wordpress.org/reference/functions/get_sample_permalink/) to get correct URL if current post's status isn't `'publish'`.
* Add deprecation notice for `wpsc_delete_cats_tags`. There is  replacement - `wpsc_delete_post_archives`.
* Call `wpsc_delete_post_archives` from function `wp_cache_post_change` - to clear all archive pages which are in relation with changed post.

It's replacement for #506. 