### PR TITLE
Add cookie helper functions to modify the cache key more easily.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ The output of WP-Cache's wp_cache_get_cookies_values() function.
 WP Super Cache has it's own plugin system. This code is loaded when WP Super Cache loads and can be used to change how caching is done. This is before most of WordPress loads so some functionality will not be available. Plugins can be located anywhere that PHP can load them. Add your own plugin by calling wpsc_add_plugin( $name ) where $name is the full filename and path to the plugin. You only need to call that function once to add it. Use wpsc_delete_plugin( $name ) to remove it from the list of loaded plugins.
 
 The cookies WP Super Cache uses to identify "known users" can be modified now by adding the names of those cookies to a list in the plugin configuration. Use wpsc_add_cookie( $name ) to add a new cookie, and wpsc_delete_cookie( $name ) to remove it. The cookie names also modify the mod_rewrite rules used by the plugin but I recommend using Simple mode caching to avoid complications with updating the .htaccess file.
+The cookie name and value are used to differenciate users so you can have one cookie, but different values for each type of user on your site for example. They'll be served different cache files.
 
 See [plugins/searchengine.php](https://github.com/Automattic/wp-super-cache/blob/4cda5c0f2218e40e118232b5bf22d227fb3206b7/plugins/searchengine.php) as an example I use for my [No Adverts for Friends](https://odd.blog/no-adverts-for-friends/) plugin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,10 @@ There is one regular WordPress filter too. Use the "do_createsupercache" filter
 to customize the checks made before caching. The filter accepts one parameter.
 The output of WP-Cache's wp_cache_get_cookies_values() function.
 
+WP Super Cache has it's own plugin system. This code is loaded when WP Super Cache loads and can be used to change how caching is done. This is before most of WordPress loads so some functionality will not be available. Plugins can be located anywhere that PHP can load them. Add your own plugin by calling wpsc_add_plugin( $name ) where $name is the full filename and path to the plugin. You only need to call that function once to add it. Use wpsc_delete_plugin( $name ) to remove it from the list of loaded plugins.
+
+The cookies WP Super Cache uses to identify "known users" can be modified now by adding the names of those cookies to a list in the plugin configuration. Use wpsc_add_cookie( $name ) to add a new cookie, and wpsc_delete_cookie( $name ) to remove it. The cookie names also modify the mod_rewrite rules used by the plugin but I recommend using Simple mode caching to avoid complications with updating the .htaccess file.
+
 See [plugins/searchengine.php](https://github.com/Automattic/wp-super-cache/blob/4cda5c0f2218e40e118232b5bf22d227fb3206b7/plugins/searchengine.php) as an example I use for my [No Adverts for Friends](https://odd.blog/no-adverts-for-friends/) plugin.
 
 ### Troubleshooting ###

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -322,6 +322,7 @@ function wp_cache_late_loader() {
 }
 
 function wp_cache_get_cookies_values() {
+	global $wpsc_cookies;
 	static $string = '';
 
 	if ( $string != '' ) {
@@ -350,6 +351,20 @@ function wp_cache_get_cookies_values() {
 
 	// If you use this hook, make sure you update your .htaccess rules with the same conditions
 	$string = do_cacheaction( 'wp_cache_get_cookies_values', $string );
+
+	if (
+		isset( $wpsc_cookies ) &&
+		is_array( $wpsc_cookies ) &&
+		! empty( $wpsc_cookies )
+	) {
+		foreach( $wpsc_cookies as $name ) {
+			if ( isset( $_COOKIE[ $name ] ) ) {
+				wp_cache_debug( "wp_cache_get_cookies_values - found extra cookie: $name" );
+				$string .= $name . "=" . $_COOKIE[ $name ] . ",";
+			}
+		}
+	}
+
 	if ( $string != '' )
 		$string = md5( $string );
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -4111,3 +4111,32 @@ function wpsc_get_plugins() {
 	global $wpsc_plugins;
 	return $wpsc_plugins;
 }
+
+function wpsc_add_cookie( $name ) {
+	global $wpsc_cookies;
+	if (
+		! isset( $wpsc_cookies ) ||
+		! is_array( $wpsc_cookies ) ||
+		! in_array( $name, $wpsc_cookies )
+	) {
+		$wpsc_cookies[] = $name;
+		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
+	}
+}
+
+function wpsc_delete_cookie( $name ) {
+	global $wpsc_cookies;
+	if (
+		isset( $wpsc_cookies ) &&
+		is_array( $wpsc_cookies ) &&
+		in_array( $name, $wpsc_cookies )
+	) {
+		unset( $wpsc_cookies[ array_search( $name, $wpsc_cookies ) ] );
+		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
+	}
+}
+
+function wpsc_get_cookies() {
+	global $wpsc_cookies;
+	return $wpsc_cookies;
+}

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3310,7 +3310,7 @@ function wpsc_get_htaccess_info() {
 	}
 	$condition_rules[] = "RewriteCond %{REQUEST_METHOD} !POST";
 	$condition_rules[] = "RewriteCond %{QUERY_STRING} ^$";
-	$condition_rules[] = "RewriteCond %{HTTP:Cookie} !^.*(comment_author_|" . wpsc_get_logged_in_cookie() . "|wp-postpass_).*$";
+	$condition_rules[] = "RewriteCond %{HTTP:Cookie} !^.*(comment_author_|" . wpsc_get_logged_in_cookie() . wpsc_get_extra_cookies() . "|wp-postpass_).*$";
 	$condition_rules[] = "RewriteCond %{HTTP:X-Wap-Profile} !^[a-z0-9\\\"]+ [NC]";
 	$condition_rules[] = "RewriteCond %{HTTP:Profile} !^[a-z0-9\\\"]+ [NC]";
 	if ( $wp_cache_mobile_enabled ) {
@@ -4139,4 +4139,16 @@ function wpsc_delete_cookie( $name ) {
 function wpsc_get_cookies() {
 	global $wpsc_cookies;
 	return $wpsc_cookies;
+}
+
+function wpsc_get_extra_cookies() {
+	global $wpsc_cookies;
+	if (
+		is_array( $wpsc_cookies ) &&
+		! empty( $wpsc_cookies )
+	) {
+		return '|' . implode( '|', $wpsc_cookies );
+	} else {
+		return '';
+	}
 }


### PR DESCRIPTION
Inspired by https://wordpress.org/support/topic/php-cookies-doesnt-work-with-wp-super-cache/
This will make it much easier for plugin authors that use cookies to
identify visitors to integrate with WP Super Cache.
Use the function wpsc_add_cookie( $name ) to add a cookie name to the
list of cookies and wpsc_delete_cookie( $name ) to remove it.

Example code to add the cookie "euCookie" used by the EU Cookie Law
plugin;
https://wordpress.org/plugins/eu-cookie-law/

--------------
function add_wpsc_cookies() {
    if ( function_exists( 'wpsc_add_cookie' ) ) {
        wpsc_add_cookie( 'euCookie' );
    }
}

add_action( 'init', 'add_wpsc_cookies' );
--------------

It's wrapped in an action on "init" to make sure that WP Super Cache is
loaded but the wpsc_add_cookie() function only needs to be called once.
Calling it multiple times does not add multiple entries for the same
cookie name.