### PR TITLE
Add wpsc_cookies and wpsc_plugins filters to modify those settings

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -83,9 +83,24 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 function wp_super_cache_init_action() {
+	global $wpsc_cookies, $wpsc_plugins;
+
 	load_plugin_textdomain( 'wp-super-cache', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 	wpsc_register_post_hooks();
+
+	$cookies = array_unique( apply_filters( 'wpsc_cookies', $wpsc_cookies ) );
+	if ( $cookies != $wpsc_cookies ) {
+		$wpsc_cookies = $cookies;
+		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
+	}
+
+	$plugins = array_unique( apply_filters( 'wpsc_plugins', $wpsc_plugins ) );
+	if ( $plugins != $wpsc_plugins ) {
+		$wpsc_plugins = $plugins;
+		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
+	}
+
 }
 add_action( 'init', 'wp_super_cache_init_action' );
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -83,23 +83,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 function wp_super_cache_init_action() {
-	global $wpsc_cookies, $wpsc_plugins;
 
 	load_plugin_textdomain( 'wp-super-cache', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 	wpsc_register_post_hooks();
-
-	$cookies = array_unique( apply_filters( 'wpsc_cookies', $wpsc_cookies ) );
-	if ( $cookies != $wpsc_cookies ) {
-		$wpsc_cookies = $cookies;
-		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
-	}
-
-	$plugins = array_unique( apply_filters( 'wpsc_plugins', $wpsc_plugins ) );
-	if ( $plugins != $wpsc_plugins ) {
-		$wpsc_plugins = $plugins;
-		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
-	}
 
 }
 add_action( 'init', 'wp_super_cache_init_action' );
@@ -4090,7 +4077,9 @@ function wpsc_add_plugin( $file ) {
 		$wpsc_plugins[] = $file;
 		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
 	}
+	return $file;
 }
+add_action( 'wpsc_add_plugin', 'wpsc_add_plugin' );
 
 function wpsc_delete_plugin( $file ) {
 	global $wpsc_plugins;
@@ -4105,7 +4094,9 @@ function wpsc_delete_plugin( $file ) {
 		unset( $wpsc_plugins[ array_search( $file, $wpsc_plugins ) ] );
 		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
 	}
+	return $file;
 }
+add_action( 'wpsc_delete_plugin', 'wpsc_delete_plugin' );
 
 function wpsc_get_plugins() {
 	global $wpsc_plugins;
@@ -4122,7 +4113,9 @@ function wpsc_add_cookie( $name ) {
 		$wpsc_cookies[] = $name;
 		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
 	}
+	return $name;
 }
+add_action( 'wpsc_add_cookie', 'wpsc_add_cookie' );
 
 function wpsc_delete_cookie( $name ) {
 	global $wpsc_cookies;
@@ -4134,7 +4127,9 @@ function wpsc_delete_cookie( $name ) {
 		unset( $wpsc_cookies[ array_search( $name, $wpsc_cookies ) ] );
 		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
 	}
+	return $name;
 }
+add_action( 'wpsc_delete_cookie', 'wpsc_delete_cookie' );
 
 function wpsc_get_cookies() {
 	global $wpsc_cookies;


### PR DESCRIPTION
These filters will allow WordPress plugins to modify the cookies and
plugins lists used by WP Super Cache instead of the add/delete functions
introduced in #574 and #580.
Duplicate entries are removed so the filter function does not need to
worry about that. The filters fire on 'init'.

Example filter code:

```
function myplugin_add_wpsc_cookies( $cookies ) {
    $cookies[] = 'myplugin';
    return $cookies;
}
add_filter( 'wpsc_cookies', 'myplugin_add_wpsc_cookies' );
```

```
function myplugin_delete_wpsc_cookies( $cookies ) {
    if ( in_array( 'myplugin', $cookies ) ) {
        unset( $cookies[ array_search( 'myplugin', $cookies ) ] );
    }
    return $cookies;
}
add_filter( 'wpsc_cookies', 'myplugin_delete_wpsc_cookies' );
```

As suggested by @johnbillion and @andreasciamanna in #580.

You can also use `do_action` to add a cookie like this:
```
do_action( 'wpsc_add_cookie', 'euCookie' );
```
Use `wpsc_delete_cookie` to remove the cookie.