### PR TITLE
Fix strncmp missing argument

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3072,7 +3072,7 @@ if ( ! function_exists( 'apache_request_headers' ) ) {
 		$headers = array();
 
 		foreach ( array_keys( $_SERVER ) as $skey ) {
-			if ( 0 === strncmp( $skey, 'HTTP_' ) ) {
+			if ( 0 === strncmp( $skey, 'HTTP_', 5 ) ) {
 				$header = implode( '-', array_map( 'ucfirst', array_slice( explode( '_', strtolower( $skey ) ) , 1 ) ) );
 				$headers[ $header ] = $_SERVER[ $skey ];
 			}

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -83,9 +83,24 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 function wp_super_cache_init_action() {
+	global $wpsc_cookies, $wpsc_plugins;
+
 	load_plugin_textdomain( 'wp-super-cache', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 	wpsc_register_post_hooks();
+
+	$cookies = array_unique( apply_filters( 'wpsc_cookies', $wpsc_cookies ) );
+	if ( $cookies != $wpsc_cookies ) {
+		$wpsc_cookies = $cookies;
+		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
+	}
+
+	$plugins = array_unique( apply_filters( 'wpsc_plugins', $wpsc_plugins ) );
+	if ( $plugins != $wpsc_plugins ) {
+		$wpsc_plugins = $plugins;
+		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
+	}
+
 }
 add_action( 'init', 'wp_super_cache_init_action' );
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -83,23 +83,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 function wp_super_cache_init_action() {
-	global $wpsc_cookies, $wpsc_plugins;
 
 	load_plugin_textdomain( 'wp-super-cache', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 	wpsc_register_post_hooks();
-
-	$cookies = array_unique( apply_filters( 'wpsc_cookies', $wpsc_cookies ) );
-	if ( $cookies != $wpsc_cookies ) {
-		$wpsc_cookies = $cookies;
-		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
-	}
-
-	$plugins = array_unique( apply_filters( 'wpsc_plugins', $wpsc_plugins ) );
-	if ( $plugins != $wpsc_plugins ) {
-		$wpsc_plugins = $plugins;
-		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
-	}
 
 }
 add_action( 'init', 'wp_super_cache_init_action' );
@@ -4090,7 +4077,9 @@ function wpsc_add_plugin( $file ) {
 		$wpsc_plugins[] = $file;
 		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
 	}
+	return $file;
 }
+add_action( 'wpsc_add_plugin', 'wpsc_add_plugin' );
 
 function wpsc_delete_plugin( $file ) {
 	global $wpsc_plugins;
@@ -4105,7 +4094,9 @@ function wpsc_delete_plugin( $file ) {
 		unset( $wpsc_plugins[ array_search( $file, $wpsc_plugins ) ] );
 		wp_cache_setting( 'wpsc_plugins', $wpsc_plugins );
 	}
+	return $file;
 }
+add_action( 'wpsc_delete_plugin', 'wpsc_delete_plugin' );
 
 function wpsc_get_plugins() {
 	global $wpsc_plugins;
@@ -4122,7 +4113,9 @@ function wpsc_add_cookie( $name ) {
 		$wpsc_cookies[] = $name;
 		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
 	}
+	return $name;
 }
+add_action( 'wpsc_add_cookie', 'wpsc_add_cookie' );
 
 function wpsc_delete_cookie( $name ) {
 	global $wpsc_cookies;
@@ -4134,7 +4127,9 @@ function wpsc_delete_cookie( $name ) {
 		unset( $wpsc_cookies[ array_search( $name, $wpsc_cookies ) ] );
 		wp_cache_setting( 'wpsc_cookies', $wpsc_cookies );
 	}
+	return $name;
 }
+add_action( 'wpsc_delete_cookie', 'wpsc_delete_cookie' );
 
 function wpsc_get_cookies() {
 	global $wpsc_cookies;


### PR DESCRIPTION
Before this fix, I was getting many `PHP Warning:  strncmp() expects exactly 3 parameters, 2 given in wp-cache-phase2.php on line 3075` as soon as any cookie was created.

I believe the original intention of using `strncmp` instead of `strcmp` was a question of performance.

As per my knowledge, `strpos` should be faster, especially when comparing the beginning of a string.

In any case, I'm keeping the use of `strncmp` and pass the missing argument which, I believe, should be `5` (i.e., the length of `HTTP_ `).