### PR TITLE
Populates $WPSC_HTTP_HOST for WP-CLI commands

### DIFF
--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -1,9 +1,13 @@
 <?php
-if ( false == isset( $_SERVER['HTTP_HOST'] ) ) {
+global $WPSC_HTTP_HOST, $blogcacheid;
+
+if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+	$WPSC_HTTP_HOST = htmlentities( $_SERVER['HTTP_HOST'] );
+} elseif ( PHP_SAPI === 'cli' && function_exists( 'get_option' ) ) {
+	$WPSC_HTTP_HOST = (string) parse_url( get_option( 'home' ), PHP_URL_HOST );
+} else {
 	$cache_enabled  = false;
 	$WPSC_HTTP_HOST = '';
-} else {
-	$WPSC_HTTP_HOST = htmlentities( $_SERVER['HTTP_HOST'] );
 }
 
 // We want to be able to identify each blog in a WordPress MU install


### PR DESCRIPTION
* Explicitly globalizes `$WPSC_HTTP_HOST` and `$blogcacheid` (WP-CLI needs it).
* Uses `get_option( 'home' )` to populate `$WPSC_HTTP_HOST`. It's possible because `wp-cache.php` loads `wp-cache-base.php` (WP-CLI doesn't load `advanced-cache.php`) when function [`get_option`](https://developer.wordpress.org/reference/functions/get_option/) exists.

Fixes #586.