### PR TITLE
Fixes admin bar rendering

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3720,7 +3720,20 @@ function uninstall_supercache( $folderPath ) { // from http://www.php.net/manual
 }
 
 function supercache_admin_bar_render() {
-	global $wp_admin_bar, $wp_cache_home_path, $current_blog;
+	global $wp_admin_bar;
+
+	if ( function_exists( '_deprecated_function' ) ) {
+		_deprecated_function( __FUNCTION__, 'WP Super Cache 1.6.4' );
+	}
+
+	wpsc_admin_bar_render( $wp_admin_bar );
+}
+
+/**
+ * Adds "Delete Cache" button in WP Admin Bar.
+ */
+function wpsc_admin_bar_render( $wp_admin_bar ) {
+	global $wp_cache_home_path, $current_blog;
 
         if ( ! function_exists( 'current_user_can' ) || ! is_user_logged_in() ) {
 		return false;
@@ -3737,7 +3750,7 @@ function supercache_admin_bar_render() {
 					'id' => 'delete-cache',
 					'title' => __( 'Delete Cache', 'wp-super-cache' ),
 					'meta' => array( 'title' => __( 'Delete cache of the current page', 'wp-super-cache' ) ),
-					'href' => wp_nonce_url( admin_url( 'index.php?action=delcachepage&path=' . urlencode( preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', $path ) ) ), 'delete-cache' )
+					'href' => wp_nonce_url( admin_url( 'index.php?action=delcachepage&path=' . urlencode( $path ) ), 'delete-cache' )
 					) );
 	}
 
@@ -3751,7 +3764,7 @@ function supercache_admin_bar_render() {
 					) );
 	}
 }
-add_action( 'wp_before_admin_bar_render', 'supercache_admin_bar_render' );
+add_action( 'admin_bar_menu', 'wpsc_admin_bar_render', 99 );
 
 function wpsc_cancel_preload() {
 	global $cache_path;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3094,6 +3094,10 @@ function wp_cache_catch_404() {
 //add_action( 'template_redirect', 'wp_cache_catch_404' );
 
 function wp_cache_favorite_action( $actions ) {
+	if ( function_exists( '_deprecated_function' ) ) {
+		_deprecated_function( __FUNCTION__, 'WP Super Cache 1.6.4' );
+	}
+
 	if ( false == wpsupercache_site_admin() )
 		return $actions;
 
@@ -3104,7 +3108,7 @@ function wp_cache_favorite_action( $actions ) {
 
 	return $actions;
 }
-add_filter( 'favorite_actions', 'wp_cache_favorite_action' );
+//add_filter( 'favorite_actions', 'wp_cache_favorite_action' );
 
 function wp_cache_plugin_notice( $plugin ) {
 	global $cache_enabled;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3733,17 +3733,15 @@ function supercache_admin_bar_render() {
  * Adds "Delete Cache" button in WP Admin Bar.
  */
 function wpsc_admin_bar_render( $wp_admin_bar ) {
-	global $wp_cache_home_path, $current_blog;
 
-        if ( ! function_exists( 'current_user_can' ) || ! is_user_logged_in() ) {
+	if ( ! function_exists( 'current_user_can' ) || ! is_user_logged_in() ) {
 		return false;
 	}
 
 	if ( ( is_singular() || is_archive() || is_front_page() || is_search() ) && current_user_can(  'delete_others_posts' ) ) {
-		$req_uri = preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', $_SERVER[ 'REQUEST_URI' ] );
-
-		$home_path = ( is_multisite() && is_object( $current_blog ) ) ? $current_blog->path : $wp_cache_home_path;
-		$path      = preg_replace( '`^' . preg_quote( rtrim( $home_path, '/' ), '`' ) . '`', '', $req_uri );
+		$site_regex = preg_quote( rtrim( (string) parse_url( get_option( 'home' ), PHP_URL_PATH ), '/' ), '`' );
+		$req_uri    = preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', $_SERVER[ 'REQUEST_URI' ] );
+		$path       = preg_replace( '`^' . $site_regex . '`', '', $req_uri );
 
 		$wp_admin_bar->add_menu( array(
 					'parent' => '',


### PR DESCRIPTION
* Action `dashmenu` is pretty deprecated. Adds deprecation notice for function `delete_cache_dashboard`.
* Fixes logic in function `supercache_admin_bar_render`. It isn't perfect but it's enough for first iteration.
*  Uses the method [`add_menu`](https://developer.wordpress.org/reference/classes/wp_admin_bar/add_menu/) in `$wp_admin_bar` to render menu into admin dashboard.

Fixes: Automattic/wp-super-cache#489, Automattic/jetpack#25556, Automattic/jetpack#25594, Automattic/wp-super-cache#971