### PR TITLE
Postponed blog detection on WP >= 4.6

### DIFF
--- a/plugins/multisite.php
+++ b/plugins/multisite.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) === true ) || defined( 'SUBDOMAIN_INSTALL' ) || defined( 'VHOST' ) || defined( 'SUNRISE' ) ) {
+if ( is_multisite() ) {
 	add_cacheaction( 'add_cacheaction', 'wp_super_cache_multisite_init' );
 }
 

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -1,9 +1,13 @@
 <?php
-if ( false == isset( $_SERVER['HTTP_HOST'] ) ) {
+global $WPSC_HTTP_HOST, $blogcacheid;
+
+if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+	$WPSC_HTTP_HOST = htmlentities( $_SERVER['HTTP_HOST'] );
+} elseif ( PHP_SAPI === 'cli' && function_exists( 'get_option' ) ) {
+	$WPSC_HTTP_HOST = (string) parse_url( get_option( 'home' ), PHP_URL_HOST );
+} else {
 	$cache_enabled  = false;
 	$WPSC_HTTP_HOST = '';
-} else {
-	$WPSC_HTTP_HOST = htmlentities( $_SERVER['HTTP_HOST'] );
 }
 
 // We want to be able to identify each blog in a WordPress MU install

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -1,5 +1,5 @@
 <?php
-global $WPSC_HTTP_HOST, $blogcacheid;
+global $WPSC_HTTP_HOST, $cache_path, $current_blog, $blogcacheid, $blog_cache_dir;
 
 if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
 	$WPSC_HTTP_HOST = htmlentities( $_SERVER['HTTP_HOST'] );
@@ -12,10 +12,11 @@ if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
 
 // We want to be able to identify each blog in a WordPress MU install
 $blogcacheid = '';
-if ( is_multisite() ) {
-	global $current_blog;
+$blog_cache_dir = $cache_path;
 
+if ( is_multisite() ) {
 	$blogcacheid = 'blog'; // main blog
+
 	if ( is_object( $current_blog ) && function_exists( 'is_subdomain_install' ) ) {
 		$blogcacheid = is_subdomain_install() ?  $current_blog->domain : trim( $current_blog->path, '/' );
 		if ( empty( $blogcacheid  ) ) {

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -8,9 +8,16 @@ if ( false == isset( $_SERVER['HTTP_HOST'] ) ) {
 
 // We want to be able to identify each blog in a WordPress MU install
 $blogcacheid = '';
-if ( ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) == true ) || defined( 'SUBDOMAIN_INSTALL' ) || defined( 'VHOST' ) || defined( 'SUNRISE' ) ) {
+if ( is_multisite() ) {
+	global $current_blog;
+
 	$blogcacheid = 'blog'; // main blog
-	if ( defined( 'SUBDOMAIN_INSTALL' ) && constant( 'SUBDOMAIN_INSTALL' ) == true ) {
+	if ( is_object( $current_blog ) && function_exists( 'is_subdomain_install' ) ) {
+		$blogcacheid = is_subdomain_install() ?  $current_blog->domain : trim( $current_blog->path, '/' );
+		if ( empty( $blogcacheid  ) ) {
+			$blogcacheid = 'blog';
+		}
+	} elseif ( ( defined('SUBDOMAIN_INSTALL') && SUBDOMAIN_INSTALL ) || ( defined( 'VHOST' ) && VHOST == 'yes' ) ) {
 		$blogcacheid = $WPSC_HTTP_HOST;
 	} else {
 		if ( isset( $base ) == false ) {
@@ -32,4 +39,5 @@ if ( ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) == tr
 		}
 		$blogcacheid = str_replace( '/', '', $blogcacheid );
 	}
+	$blog_cache_dir = str_replace( '//', '/', $cache_path . 'blogs/' . $blogcacheid . '/' );
 }

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -101,8 +101,11 @@ if ( $cache_compression ) {
 	$wp_cache_gzip_encoding = gzip_accepted();
 }
 
+$wpsc_wp_gte_46 = function_exists( 'add_filter' ) && version_compare( $GLOBALS['wp_version'], '4.6', '>=' );
+
 add_cacheaction( 'supercache_filename_str', 'wp_cache_check_mobile' );
-if ( function_exists( 'add_filter' ) ) { // loaded since WordPress 4.6
+if ( $wpsc_wp_gte_46 ) {
+	// loaded since WordPress 4.6
 	add_filter( 'supercache_filename_str', 'wp_cache_check_mobile' );
 }
 
@@ -126,11 +129,7 @@ if ( defined( 'DOING_CRON' ) ) {
 }
 
 // WordPress 4.6 introduces action ms_loaded.
-if ( is_multisite() &&
-	empty( $wp_super_cache_late_init ) &&
-	version_compare( $wp_version, '4.6', '>=' ) &&
-	function_exists( 'add_action' )
-) {
+if ( is_multisite() && $wpsc_wp_gte_46 && empty( $wp_super_cache_late_init ) ) {
 	add_action( 'ms_loaded', 'wp_cache_serve_cache_file' );
 }
 elseif ( ! isset( $wp_super_cache_late_init ) || ( isset( $wp_super_cache_late_init ) && false == $wp_super_cache_late_init ) ) {

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -20,11 +20,12 @@ if ( defined( 'DISABLE_SUPERCACHE' ) ) {
 
 require WPCACHEHOME . 'wp-cache-base.php';
 
-if ( $blogcacheid != '' ) {
+// Moved to wp-cache-base.php
+/*if ( $blogcacheid != '' ) {
 	$blog_cache_dir = str_replace( '//', '/', $cache_path . 'blogs/' . $blogcacheid . '/' );
 } else {
 	$blog_cache_dir = $cache_path;
-}
+}*/
 
 $wp_cache_phase1_loaded = true;
 

--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -125,6 +125,14 @@ if ( defined( 'DOING_CRON' ) ) {
 	return true;
 }
 
-if ( ! isset( $wp_super_cache_late_init ) || ( isset( $wp_super_cache_late_init ) && false == $wp_super_cache_late_init ) ) {
+// WordPress 4.6 introduces action ms_loaded.
+if ( is_multisite() &&
+	empty( $wp_super_cache_late_init ) &&
+	version_compare( $wp_version, '4.6', '>=' ) &&
+	function_exists( 'add_action' )
+) {
+	add_action( 'ms_loaded', 'wp_cache_serve_cache_file' );
+}
+elseif ( ! isset( $wp_super_cache_late_init ) || ( isset( $wp_super_cache_late_init ) && false == $wp_super_cache_late_init ) ) {
 	wp_cache_serve_cache_file();
 }

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -46,6 +46,12 @@ function wp_cache_serve_cache_file() {
 	global $key, $blogcacheid, $wp_cache_request_uri, $file_prefix, $blog_cache_dir, $meta_file, $cache_file, $cache_filename, $meta_pathname, $wp_cache_gzip_encoding, $meta;
 	global $wp_cache_object_cache, $cache_compression, $wp_cache_slash_check, $wp_supercache_304, $wp_cache_home_path, $wp_cache_no_cache_for_get;
 	global $wp_cache_disable_utf8, $wp_cache_mfunc_enabled, $wpsc_served_header;
+	global $current_blog;
+
+	// Fixes $blogcacheid and $blog_cache_dir if ms-settings.php is loaded.
+	if ( is_multisite() && is_object( $current_blog ) ) {
+		require WPCACHEHOME . 'wp-cache-base.php';
+	}
 
 	if ( wpsc_is_backend() ) {
 		wp_cache_debug( 'Not serving wp-admin requests.', 5 );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1284,7 +1284,7 @@ table.wpsc-settings-table {
 			wp_nonce_field('wp-cache');
 			echo "</form>\n";
 
-			if ( ( defined( 'VHOST' ) || defined( 'SUBDOMAIN_INSTALL' ) || defined( 'SUNRISE' ) || ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) == true  ) ) && wpsupercache_site_admin() ) {
+			if ( is_multisite() && wpsupercache_site_admin() ) {
 				echo '<form name="wp_cache_content_delete" action="#listfiles" method="post">';
 				echo '<input type="hidden" name="wp_delete_all_cache" />';
 				echo '<div class="submit"><input id="deleteallpost" class="button-secondary" type="submit" ' . SUBMITDISABLED . 'value="' . __( 'Delete Cache On All Blogs', 'wp-super-cache' ) . '" /></div>';
@@ -2844,7 +2844,7 @@ function wp_cache_delete_buttons() {
 	echo '<div class="submit" style="float:left;margin-left:10px"><input id="deletepost" class="button-secondary" type="submit" ' . SUBMITDISABLED . 'value="' . __( 'Delete Cache', 'wp-super-cache' ) . '" /></div>';
 	wp_nonce_field('wp-cache');
 	echo "</form>\n";
-	if ( ( defined( 'VHOST' ) || defined( 'SUBDOMAIN_INSTALL' ) || defined( 'SUNRISE' ) || ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) == true ) ) && wpsupercache_site_admin() ) {
+	if ( is_multisite() && wpsupercache_site_admin() ) {
 		echo '<form name="wp_cache_content_delete" action="#listfiles" method="post">';
 		echo '<input type="hidden" name="wp_delete_all_cache" />';
 		echo '<div class="submit" style="float:left;margin-left:10px"><input id="deleteallpost" class="button-secondary" type="submit" ' . SUBMITDISABLED . 'value="' . __( 'Delete Cache On All Blogs', 'wp-super-cache' ) . '" /></div>';
@@ -2976,6 +2976,8 @@ function wp_cache_clean_legacy_files( $dir, $file_prefix ) {
 		return false;
 
 	if ( $handle = @opendir( $dir ) ) {
+		$curr_blog_id = is_multisite() ? get_current_blog_id() : false;
+
 		while ( false !== ( $file = readdir( $handle ) ) ) {
 			if ( is_file( $dir . $file ) == false || $file == 'index.html' ) {
 				continue;
@@ -2988,8 +2990,9 @@ function wp_cache_clean_legacy_files( $dir, $file_prefix ) {
 					@unlink( $dir . 'meta/' . str_replace( '.html', '.meta', $file ) );
 				} else {
 					$meta = json_decode( wp_cache_get_legacy_cache( $dir . 'meta/' . $file ), true );
-					if ( ( defined( 'VHOST' ) || defined( 'SUBDOMAIN_INSTALL' ) || defined( 'SUNRISE' ) || ( defined( 'WP_ALLOW_MULTISITE' ) && constant( 'WP_ALLOW_MULTISITE' ) == true ) ) && $meta[ 'blog_id' ] != $wpdb->blogid )
+					if ( $curr_blog_id && $curr_blog_id !== (int) $meta['blog_id'] ) {
 						continue;
+					}
 					@unlink( $dir . $file);
 					@unlink( $dir . 'meta/' . $file);
 				}


### PR DESCRIPTION
* Uses [`is_multisite`](https://codex.wordpress.org/Function_Reference/is_multisite). It's safe because it's defined in [`wp-includes/load.php`](https://github.com/WordPress/WordPress/blob/3.0-branch/wp-includes/load.php#L571-L586).
* [WordPress 4.6](https://make.wordpress.org/core/2016/07/08/multisite-focused-changes-in-4-6/) introduces hook [`ms_loaded`](https://developer.wordpress.org/reference/hooks/ms_loaded/) ( This action fires after multisite's bootstrap has finished and when the [`$current_site`](https://codex.wordpress.org/WPMU_Global_Variables) and [`$current_blog`](https://codex.wordpress.org/WPMU_Global_Variables) globals are populated). Running of function `wp_cache_serve_cache_file` is little postponed to we can get correct blog's domain and path (It loads [few more files](https://github.com/WordPress/WordPress/blob/4.9-branch/wp-settings.php#L92-L126) - probably 15-30ms more for multisite installations before serving file).
