### PR TITLE
Bump minimal requirement to WP 3.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 * Tags: performance, caching, wp-cache, wp-super-cache, cache
 * Tested up to: 4.9.8
 * Stable tag: 1.6.3
-* Requires at least: 3.0
+* Requires at least: 3.1
 * Requires PHP: 5.2.4
 * License: GPLv2 or later
 * License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I've installed PHP 5.2.4 and Wordpress 3.0. We've to change minimal requirement to WP 3.1 because there are couple functions which are introduced in 3.1:

- [`submit_button`](https://codex.wordpress.org/Function_Reference/submit_button)
- `global $wp_admin_bar` and method [add_menu](https://codex.wordpress.org/Class_Reference/WP_Admin_Bar/add_menu)

