### PR TITLE
Populates globals in WP-CLI environment

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -65,9 +65,21 @@ wpsc_init();
  * WP-CLI requires explicit declaration of global variables.
  * It's minimal list of global variables.
  */
-global $super_cache_enabled, $cache_enabled, $wp_cache_home_path, $cache_path;
-global $wp_cache_mutex_disabled, $mutex_filename, $sem_id;
+global $super_cache_enabled, $cache_enabled, $wp_cache_mod_rewrite, $wp_cache_home_path, $cache_path, $file_prefix;
+global $wp_cache_mutex_disabled, $mutex_filename, $sem_id, $wp_super_cache_late_init;
+global $cache_compression, $cache_max_time, $wp_cache_shutdown_gc, $cache_rebuild_files;
+global $wp_super_cache_debug, $wp_super_cache_advanced_debug, $wp_cache_debug_level, $wp_cache_debug_to_file;
+global $wp_cache_debug_log, $wp_cache_debug_ip, $wp_cache_debug_username, $wp_cache_debug_email;
+global $cache_time_interval, $cache_scheduled_time, $cache_schedule_interval, $cache_schedule_type, $cache_gc_email_me;
+global $wp_cache_preload_on, $wp_cache_preload_interval, $wp_cache_preload_posts, $wp_cache_preload_taxonomies;
+global $wp_cache_preload_email_me, $wp_cache_preload_email_volume;
+global $wp_cache_mobile, $wp_cache_mobile_enabled, $wp_cache_mobile_browsers, $wp_cache_mobile_prefixes;
 global $wp_cache_config_file, $wp_cache_config_file_sample;
+
+// WP-CLI: Hotfix for $blog_cache_dir for single site. It'll be removed after merging #590
+if ( empty( $GLOBALS['blog_cache_dir'] ) && ! is_multisite() ) {
+	$GLOBALS['blog_cache_dir'] = $cache_path;
+}
 
 if( !@include($wp_cache_config_file) ) {
 	get_wpcachehome();


### PR DESCRIPTION
* Explicit declaration of globals in `wp-cache.php` before loading config file.

Fixes: #440 
Partially fixes: #431