### PR TITLE
Removes apache_response_headers and uses only headers_list

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1374,79 +1374,76 @@ function wp_cache_user_agent_is_rejected() {
 
 function wp_cache_get_response_headers() {
 	static $known_headers = array(
-						'Access-Control-Allow-Origin',
-						'Accept-Ranges',
-						'Age',
-						'Allow',
-						'Cache-Control',
-						'Connection',
-						'Content-Encoding',
-						'Content-Language',
-						'Content-Length',
-						'Content-Location',
-						'Content-MD5',
-						'Content-Disposition',
-						'Content-Range',
-						'Content-Type',
-						'Date',
-						'ETag',
-						'Expires',
-						'Last-Modified',
-						'Link',
-						'Location',
-						'P3P',
-						'Pragma',
-						'Proxy-Authenticate',
-						"Referrer-Policy",
-						'Refresh',
-						'Retry-After',
-						'Server',
-						'Status',
-						'Strict-Transport-Security',
-						'Trailer',
-						'Transfer-Encoding',
-						'Upgrade',
-						'Vary',
-						'Via',
-						'Warning',
-						'WWW-Authenticate',
-						'X-Frame-Options',
-						'Public-Key-Pins',
-						'X-XSS-Protection',
-						'Content-Security-Policy',
-						"X-Pingback",
-						'X-Content-Security-Policy',
-						'X-WebKit-CSP',
-						'X-Content-Type-Options',
-						'X-Powered-By',
-						'X-UA-Compatible',
-						'X-Robots-Tag',
-					);
+		'Access-Control-Allow-Origin',
+		'Accept-Ranges',
+		'Age',
+		'Allow',
+		'Cache-Control',
+		'Connection',
+		'Content-Encoding',
+		'Content-Language',
+		'Content-Length',
+		'Content-Location',
+		'Content-MD5',
+		'Content-Disposition',
+		'Content-Range',
+		'Content-Type',
+		'Date',
+		'ETag',
+		'Expires',
+		'Last-Modified',
+		'Link',
+		'Location',
+		'P3P',
+		'Pragma',
+		'Proxy-Authenticate',
+		'Referrer-Policy',
+		'Refresh',
+		'Retry-After',
+		'Server',
+		'Status',
+		'Strict-Transport-Security',
+		'Trailer',
+		'Transfer-Encoding',
+		'Upgrade',
+		'Vary',
+		'Via',
+		'Warning',
+		'WWW-Authenticate',
+		'X-Frame-Options',
+		'Public-Key-Pins',
+		'X-XSS-Protection',
+		'Content-Security-Policy',
+		'X-Pingback',
+		'X-Content-Security-Policy',
+		'X-WebKit-CSP',
+		'X-Content-Type-Options',
+		'X-Powered-By',
+		'X-UA-Compatible',
+		'X-Robots-Tag',
+	);
+
+	if ( ! function_exists( 'headers_list' ) ) {
+		return array();
+	}
 
 	$known_headers = apply_filters( 'wpsc_known_headers', $known_headers );
 
-	if ( ! isset( $known_headers[ 'age' ] ) ) {
+	if ( ! isset( $known_headers['age'] ) ) {
 		$known_headers = array_map( 'strtolower', $known_headers );
 	}
 
 	$headers = array();
-	if ( function_exists( 'apache_response_headers' ) ) {
-		$headers = apache_response_headers();
-	}
-	if ( empty( $headers ) && function_exists( 'headers_list' ) ) {
-		$headers = array();
-		foreach( headers_list() as $hdr ) {
-			$header_parts = explode( ':', $hdr, 2 );
-			$header_name  = isset( $header_parts[0] ) ? trim( $header_parts[0] ) : '';
-			$header_value = isset( $header_parts[1] ) ? trim( $header_parts[1] ) : '';
+	foreach ( headers_list() as $hdr ) {
+		$ptr = strpos( $hdr, ':' );
 
-			$headers[$header_name] = $header_value;
+		if ( empty( $ptr ) ) {
+			continue;
 		}
-	}
 
-	foreach( $headers as $key => $value ) {
-		if ( ! in_array( strtolower( $key ), $known_headers ) ) {
-			unset( $headers[ $key ] );
+		$hdr_key = rtrim( substr( $hdr, 0, $ptr ) );
+		if ( in_array( strtolower( $hdr_key ), $known_headers, true ) ) {
+			$headers[ $hdr_key ] = ltrim( substr( $hdr, $ptr + 1 ) );
 		}
 	}
 


### PR DESCRIPTION
Since [apache_response_headers](http://php.net/manual/en/function.apache-response-headers.php)  does not work properly in PHP 7.x, I've reported [the bug 76954](https://bugs.php.net/bug.php?id=76954). This function is only required for PHP 4.x which is pretty outdated and we can use only [headers_list](http://php.net/manual/en/function.headers-list.php) (because WPSC requires PHP>=5.2.4) which returns array of raw headers. I've checked multiple versions of Apache/PHP (until I was researching the bug in PHP) and everything works properly.

I've created https://github.com/php/php-src/pull/3566 which fixes the bug in PHP 7.x. Based on this PR (and my research), I've optimized `wp_cache_get_response_headers`(PHPCS fixes and avoid double processing of headers).

Short summary:
* Removes Removes apache_response_headers since bug.
* Optimize PHP code in wp_cache_get_response_headers.

Fixes: #539, [X-Robots-Tag lost when caching](https://wordpress.org/support/topic/x-robot-tag-lost-when-caching/)