### PR TITLE
Improves logic for logged in users

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -73,7 +73,11 @@ if (
 
 $wp_start_time = microtime();
 
-if ( $wp_cache_not_logged_in && wp_cache_get_cookies_values() ) {
+if ( wpsc_is_backend() ) {
+	return true;
+}
+
+if ( $wp_cache_not_logged_in && wpsc_get_auth_cookies() ) {
 	wp_cache_debug( 'Caching disabled for logged in users on settings page.' );
 	return true;
 }
@@ -83,7 +87,6 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon ) {
 }
 
 do_cacheaction( 'cache_init' );
-
 
 if ( ! $cache_enabled || ( isset( $_SERVER['REQUEST_METHOD'] ) && in_array( $_SERVER['REQUEST_METHOD'], array( 'POST', 'PUT', 'DELETE' ) ) ) || isset( $_GET['customize_changeset_uuid'] ) ) {
 	return true;


### PR DESCRIPTION
* Creates new function  `wpsc_get_auth_cookies` which returns authentication cookies.
* Uses `wpsc_get_auth_cookies` in `wp-cache-phase1.php` to check is user logged.
* Uses [is_user_logged_in](https://developer.wordpress.org/reference/functions/is_user_logged_in/) before storing cache file.
* Improves function `wp_supercache_cache_for_admins`.

Fixes: Automattic/wp-super-cache#897,#620.
Replaces: Automattic/wp-super-cache#616.