### PR TITLE
Only update new settings and use a temporary file to avoid corruption.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1109,13 +1109,20 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 	foreach( (array) $lines as $line ) {
-		if ( preg_match("/$old/", $line)) {
+		if ( trim( $new ) == trim( $line ) ) {
+			wp_cache_debug( "Setting not changed: $new" );
+			return false;
+		} elseif ( preg_match( "/$old/", $line ) ) {
+			wp_cache_debug( "Changing line: " . trim( $line ) . " to *$new*" );
 			$found = true;
-			break;
 		}
 	}
 
-	$fd = fopen( $my_file, 'w' );
+	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], 'wpsc' );
+	rename( $tmp_config_filename, $tmp_wpcache_filename . ".php" );
+	$tmp_config_filename .= ".php";
+	wp_cache_debug( 'Writing to ' . $tmp_config_filename );
+	$fd = fopen( $tmp_config_filename, 'w' );
 	if ( ! $fd ) {
 		if ( function_exists( 'set_transient' ) ) {
 			set_transient( 'wpsc_config_error', 'config_file_ro', 10 );
@@ -1144,6 +1151,8 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 	fclose( $fd );
+	rename( $tmp_config_filename, $my_file );
+	wp_cache_debug( 'Copying ' . $tmp_config_filename . ' to ' . $my_file );
 
 	if ( function_exists( "opcache_invalidate" ) ) {
 		@opcache_invalidate( $my_file );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1110,10 +1110,10 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	}
 	foreach( (array) $lines as $line ) {
 		if ( trim( $new ) == trim( $line ) ) {
-			wp_cache_debug( "Setting not changed: $new" );
+			wp_cache_debug( "wp_cache_replace_line: setting not changed - $new" );
 			return false;
 		} elseif ( preg_match( "/$old/", $line ) ) {
-			wp_cache_debug( "Changing line: " . trim( $line ) . " to *$new*" );
+			wp_cache_debug( "wp_cache_replace_line: changing line " . trim( $line ) . " to *$new*" );
 			$found = true;
 		}
 	}
@@ -1121,7 +1121,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], 'wpsc' );
 	rename( $tmp_config_filename, $tmp_wpcache_filename . ".php" );
 	$tmp_config_filename .= ".php";
-	wp_cache_debug( 'Writing to ' . $tmp_config_filename );
+	wp_cache_debug( 'wp_cache_replace_line: writing to ' . $tmp_config_filename );
 	$fd = fopen( $tmp_config_filename, 'w' );
 	if ( ! $fd ) {
 		if ( function_exists( 'set_transient' ) ) {
@@ -1152,7 +1152,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	}
 	fclose( $fd );
 	rename( $tmp_config_filename, $my_file );
-	wp_cache_debug( 'Copying ' . $tmp_config_filename . ' to ' . $my_file );
+	wp_cache_debug( 'wp_cache_replace_line: moved ' . $tmp_config_filename . ' to ' . $my_file );
 
 	if ( function_exists( "opcache_invalidate" ) ) {
 		@opcache_invalidate( $my_file );


### PR DESCRIPTION
Fixes #648
The configuration file can be corrupted if multiple writers try to
update it at once. This patch updates a temporary file that is renamed
to the original name which should fix this.
It also limits updates to settings that have been updated. This should
decrease updates to the file by a huge amount.