### PR TITLE
When updating settings always update blank lines.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1105,7 +1105,10 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 	foreach( (array) $lines as $line ) {
-		if ( trim( $new ) == trim( $line ) ) {
+		if (
+			trim( $new ) != '' &&
+			trim( $new ) == trim( $line )
+		) {
 			wp_cache_debug( "wp_cache_replace_line: setting not changed - $new" );
 			return false;
 		} elseif ( preg_match( "/$old/", $line ) ) {


### PR DESCRIPTION
If a new line is blank we don't want to test it against the current
line because a blank link will match the new line. This happens when
uninstalling or deactivating the plugin and removing WP_CACHE or
WPCACHEHOME from wp-config.php