### PR TITLE
Fix updating wpcachehome

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1110,9 +1110,11 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 			trim( $new ) == trim( $line )
 		) {
 			wp_cache_debug( "wp_cache_replace_line: setting not changed - $new" );
+			set_transient( 'wpsc_config_error', 'setting not changed', 10 );
 			return false;
 		} elseif ( preg_match( "/$old/", $line ) ) {
 			wp_cache_debug( "wp_cache_replace_line: changing line " . trim( $line ) . " to *$new*" );
+			set_transient( 'wpsc_config_error', 'setting changed', 10 );
 			$found = true;
 		}
 	}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1060,13 +1060,13 @@ function wp_cache_setting( $field, $value ) {
 
 	$GLOBALS[ $field ] = $value;
 	if ( is_numeric( $value ) ) {
-		wp_cache_replace_line( '^ *\$' . $field, "\$$field = $value;", $wp_cache_config_file );
+		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = $value;", $wp_cache_config_file );
 	} elseif ( is_object( $value ) || is_array( $value ) ) {
 		$text = var_export( $value, true );
 		$text = preg_replace( '/[\s]+/', ' ', $text );
-		wp_cache_replace_line( '^ *\$' . $field, "\$$field = $text;", $wp_cache_config_file );
+		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = $text;", $wp_cache_config_file );
 	} else {
-		wp_cache_replace_line( '^ *\$' . $field, "\$$field = '$value';", $wp_cache_config_file );
+		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = '$value';", $wp_cache_config_file );
 	}
 }
 
@@ -1110,11 +1110,9 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 			trim( $new ) == trim( $line )
 		) {
 			wp_cache_debug( "wp_cache_replace_line: setting not changed - $new" );
-			set_transient( 'wpsc_config_error', 'setting not changed', 10 );
-			return false;
+			return true;
 		} elseif ( preg_match( "/$old/", $line ) ) {
 			wp_cache_debug( "wp_cache_replace_line: changing line " . trim( $line ) . " to *$new*" );
-			set_transient( 'wpsc_config_error', 'setting changed', 10 );
 			$found = true;
 		}
 	}

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2620,7 +2620,6 @@ function wp_cache_check_link() {
 		echo "<li>" . sprintf( __( 'Make %1$s writable using the chmod command through your ftp or server software. (<em>chmod 777 %1$s</em>) and refresh this page. This is only a temporary measure and you&#8217;ll have to make it read only afterwards again. (Change 777 to 755 in the previous command)', 'wp-super-cache' ), WP_CONTENT_DIR ) . "</li>";
 		echo "<li>" . sprintf( __( 'Refresh this page to update <em>%s/advanced-cache.php</em>', 'wp-super-cache' ), WP_CONTENT_DIR ) . "</li></ol>";
 		echo sprintf( __( 'If that doesn&#8217;t work, make sure the file <em>%s/advanced-cache.php</em> doesn&#8217;t exist:', 'wp-super-cache' ), WP_CONTENT_DIR ) . "<ol>";
-		printf( __( '<li>Open <em>%1$s</em> in a text editor.</li><li>Change the text <em>CACHEHOME</em> to <em>%2$s</em></li><li> Save the file and copy it to <em>%3$s</em> and refresh this page.</li>', 'wp-super-cache' ), $wp_cache_file, WPCACHEHOME, $wp_cache_link );
 		echo "</ol>";
 		echo "</div>";
 		return false;

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2642,7 +2642,13 @@ function wp_cache_check_global_config() {
 	}
 
 	$line = 'define(\'WP_CACHE\', true);';
-	if (!is_writeable_ACLSafe($global) || !wp_cache_replace_line('define *\( *\'WP_CACHE\'', $line, $global) ) {
+	if (
+		! is_writeable_ACLSafe( $global_config_file ) ||
+		(
+			! wp_cache_replace_line( 'define *\( *\'WP_CACHE\'', $line, $global_config_file ) &&
+			get_transient( 'wpsc_config_error' ) != 'setting not changed'
+		)
+	) {
 		if ( defined( 'WP_CACHE' ) && constant( 'WP_CACHE' ) == false ) {
 			echo '<div class="notice notice-error">' . __( "<h4>WP_CACHE constant set to false</h4><p>The WP_CACHE constant is used by WordPress to load the code that serves cached pages. Unfortunately, it is set to false. Please edit your wp-config.php and add or edit the following line above the final require_once command:<br /><br /><code>define('WP_CACHE', true);</code></p>", 'wp-super-cache' ) . "</div>";
 		} else {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2566,7 +2566,13 @@ function wp_cache_create_advanced_cache() {
 		return false;
 	}
 
-	if ( !is_writeable_ACLSafe($global_config_file) || !wp_cache_replace_line('define *\( *\'WPCACHEHOME\'', $line, $global_config_file ) ) {
+	if (
+		! is_writeable_ACLSafe( $global_config_file ) ||
+		(
+			! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', $line, $global_config_file ) &&
+			get_transient( 'wpsc_config_error' ) != 'setting not changed'
+		)
+	) {
 		echo '<div class="notice notice-error"><h4>' . __( 'Warning', 'wp-super-cache' ) . "! <em>" . sprintf( __( 'Could not update %s!</em> WPCACHEHOME must be set in config file.', 'wp-super-cache' ), $global_config_file ) . "</h4></div>";
 		return false;
 	}
@@ -3725,11 +3731,25 @@ function wp_cache_disable_plugin( $delete_config_file = true ) {
 
 	if ( apply_filters( 'wpsc_enable_wp_config_edit', true ) ) {
 		$line = 'define(\'WP_CACHE\', true);';
-		if ( strpos( file_get_contents( $global_config_file ), $line ) && ( !is_writeable_ACLSafe( $global_config_file ) || !wp_cache_replace_line( 'define *\( *\'WP_CACHE\'', '', $global_config_file ) ) ) {
+		if (
+			strpos( file_get_contents( $global_config_file ), $line ) &&
+			(
+				! is_writeable_ACLSafe( $global_config_file ) ||
+				! wp_cache_replace_line( 'define*\(*\'WP_CACHE\'', '', $global_config_file ) &&
+				get_transient( 'wpsc_config_error' ) != 'setting not changed'
+			)
+		) {
 			wp_die( "Could not remove WP_CACHE define from $global_config_file. Please edit that file and remove the line containing the text 'WP_CACHE'. Then refresh this page." );
 		}
 		$line = 'define( \'WPCACHEHOME\',';
-		if ( strpos( file_get_contents( $global_config_file ), $line ) && ( !is_writeable_ACLSafe( $global_config_file ) || !wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', '', $global_config_file ) ) ) {
+		if (
+			strpos( file_get_contents( $global_config_file ), $line ) &&
+			(
+				! is_writeable_ACLSafe( $global_config_file ) ||
+				! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', '', $global_config_file ) &&
+				get_transient( 'wpsc_config_error' ) != 'setting not changed'
+			)
+		) {
 			wp_die( "Could not remove WPCACHEHOME define from $global_config_file. Please edit that file and remove the line containing the text 'WPCACHEHOME'. Then refresh this page." );
 		}
 	} elseif ( function_exists( 'wp_cache_debug' ) ) {


### PR DESCRIPTION
wp_cache_replace_line() used to return false when a setting hadn't changed but also did that when a fatal error occurred. This patch changes it so it returns true if a setting hasn't changed.
This had been used when enabling or disabling the cache so I had to change those bits of code too.
However, it makes checking for fatal errors much easier now.