### PR TITLE
Added support for ONLY_SUPERCACHE and DONT_SERVE_CACHE_FILE constants

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -77,7 +77,7 @@ function wp_cache_serve_cache_file() {
 			wp_cache_debug( 'Meta array from object cache corrupt. Ignoring cache.', 1 );
 			return true;
 		}
-	} elseif ( ( $cache_file && file_exists( $cache_file ) ) || file_exists( get_current_url_supercache_dir() . 'meta-' . $cache_filename ) ) {
+	} elseif ( !defined( 'ONLY_SUPERCACHE' ) && ( ( $cache_file && file_exists( $cache_file ) ) || file_exists( get_current_url_supercache_dir() . 'meta-' . $cache_filename ) ) ) {
 		if ( file_exists( get_current_url_supercache_dir() . 'meta-' . $cache_filename ) ) {
 			$cache_file = get_current_url_supercache_dir() . $cache_filename;
 			$meta_pathname = get_current_url_supercache_dir() . 'meta-' . $cache_filename;
@@ -1897,6 +1897,11 @@ function wp_cache_get_ob(&$buffer) {
 	$tmp_wpcache_filename = $cache_path . uniqid( mt_rand(), true ) . '.tmp';
 
 	$supercacheonly = false;
+
+	if( defined( 'ONLY_SUPERCACHE' ) ) {
+		$supercacheonly = true;
+	}
+
 	if( $super_cache_enabled ) {
 		if ( wp_cache_get_cookies_values() == '' && empty( $_GET ) ) {
 			wp_cache_debug( 'Anonymous user detected. Only creating Supercache file.', 3 );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -57,6 +57,11 @@ function wp_cache_serve_cache_file() {
 		return false;
 	}
 
+	if ( defined( 'DONT_SERVE_CACHE_FILE' ) && DONT_SERVE_CACHE_FILE ) {
+		wp_cache_debug( 'The DONT_SERVE_CACHE_FILE is defined. Cache serving will not be done by PHP.', 5 );
+		return false;
+	}
+
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname
 
 	if ( $wp_cache_object_cache && wp_cache_get_cookies_values() == '' ) {


### PR DESCRIPTION
We just wanted to use the supercached, static HTML files, and got a lot of issues with the cached PHP files. By defining the constant `ONLY_SUPERCACHE` in `wp-config.php`, no cached PHP file is ever generated.

We also added support for totally ignoring any cached file by defining the constant `DONT_SERVE_CACHE_FILE`, as we are letting the web server do the serving of the supercached files. This saves us some unnecessary file lookups.