### PR TITLE
Rename the temp config file correctly and remove wp-admin/.php files

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1118,7 +1118,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	}
 
 	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], 'wpsc' );
-	rename( $tmp_config_filename, $tmp_wpcache_filename . ".php" );
+	rename( $tmp_config_filename, $tmp_config_filename. ".php" );
 	$tmp_config_filename .= ".php";
 	wp_cache_debug( 'wp_cache_replace_line: writing to ' . $tmp_config_filename );
 	$fd = fopen( $tmp_config_filename, 'w' );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -103,6 +103,9 @@ function wp_super_cache_init_action() {
 
 	wpsc_register_post_hooks();
 
+	if ( is_admin() ) {
+		wpsc_fix_164();
+	}
 }
 add_action( 'init', 'wp_super_cache_init_action' );
 
@@ -4282,4 +4285,27 @@ function wpsc_get_extra_cookies() {
 	} else {
 		return '';
 	}
+}
+
+/*
+ * 1.6.4 created an empty file called wp-admin/.php that must be cleaned up.
+ */
+function wpsc_fix_164() {
+	global $wpsc_fix_164;
+
+	if (
+		isset( $wpsc_fix_164 ) &&
+		$wpsc_fix_164
+	) {
+		return false;
+	}
+
+	if (
+		file_exists( ABSPATH . '/wp-admin/.php' ) &&
+		0 == filesize( ABSPATH . '/wp-admin/.php' )
+	) {
+		@unlink( ABSPATH . '/wp-admin/.php' );
+	}
+
+	wp_cache_setting( 'wpsc_fix_164', 1 );
 }


### PR DESCRIPTION
The rename created a file called ".php" in wp-admin before writing to
the configuration file. The file is empty but this patch adds a fixer
function to delete it and also fixes the rename.

Reported:
https://wordpress.org/support/topic/php-notice-undefined-variable-13/
https://wordpress.org/support/topic/wp-super-cache-created-a-stray-php/