### PR TITLE
Check if WPCACHEHOME exists in the global config file before adding it.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2585,9 +2585,13 @@ function wp_cache_create_advanced_cache() {
 		return false;
 	}
 
+	$file = file_get_contents( $global_config_file );
 	if (
-		! is_writeable_ACLSafe( $global_config_file ) ||
-		! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', $line, $global_config_file )
+		! strpos( $file, "WPCACHEHOME" ) &&
+		(
+			! is_writeable_ACLSafe( $global_config_file ) ||
+			! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', $line, $global_config_file )
+		)
 	) {
 		echo '<div class="notice notice-error"><h4>' . __( 'Warning', 'wp-super-cache' ) . "! <em>" . sprintf( __( 'Could not update %s!</em> WPCACHEHOME must be set in config file.', 'wp-super-cache' ), $global_config_file ) . "</h4></div>";
 		return false;


### PR DESCRIPTION
This fixes a problem adding the advanced-cache.php where it fails if the
file wp-config.php is read only. It now checks if WPCACHEHOME is in the
config file before checking if it's readonly.
ref: https://wordpress.org/support/topic/wpcachehome-must-be-set-in-config-file/