### PR TITLE
Check if $super_cache_enabled is true this way

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -878,7 +878,7 @@ table.wpsc-settings-table {
 	}
 
 	if ( 'preload' === $curr_tab ) {
-		if ( true === $super_cache_enabled && ! defined( 'DISABLESUPERCACHEPRELOADING' ) ) {
+		if ( true == $super_cache_enabled && ! defined( 'DISABLESUPERCACHEPRELOADING' ) ) {
 			global $wp_cache_preload_interval, $wp_cache_preload_on, $wp_cache_preload_taxonomies, $wp_cache_preload_email_me, $wp_cache_preload_email_volume, $wp_cache_preload_posts, $wpdb;
 			$count = wpsc_post_count();
 			if ( $count > 1000 ) {


### PR DESCRIPTION
In 1.6.5 $super_cache_enabled was saved as 1 rather than true. This
check failed so I'm changing it back to "==" and also fixed saving of
$super_cache_enabled in #676 because I don't want users to toggle
caching just to use preload again.