### PR TITLE
Also check if WPCACHEHOME is set correctly when checking it.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2578,16 +2578,26 @@ function wp_cache_create_advanced_cache() {
 		return false;
 	}
 
-	$file = file_get_contents( $global_config_file );
 	if (
-		! strpos( $file, "WPCACHEHOME" ) &&
+		! strpos( file_get_contents( $global_config_file ), "WPCACHEHOME" ) ||
 		(
-			! is_writeable_ACLSafe( $global_config_file ) ||
-			! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', $line, $global_config_file )
+			defined( 'WPCACHEHOME' ) &&
+			(
+				constant( 'WPCACHEHOME' ) == '' ||
+				(
+					constant( 'WPCACHEHOME' ) != '' &&
+					! file_exists( constant( 'WPCACHEHOME' ) . '/wp-cache.php' )
+				)
+			)
 		)
 	) {
-		echo '<div class="notice notice-error"><h4>' . __( 'Warning', 'wp-super-cache' ) . "! <em>" . sprintf( __( 'Could not update %s!</em> WPCACHEHOME must be set in config file.', 'wp-super-cache' ), $global_config_file ) . "</h4></div>";
-		return false;
+		if (
+			! is_writeable_ACLSafe( $global_config_file ) ||
+			! wp_cache_replace_line( 'define *\( *\'WPCACHEHOME\'', $line, $global_config_file )
+		) {
+			echo '<div class="notice notice-error"><h4>' . __( 'Warning', 'wp-super-cache' ) . "! <em>" . sprintf( __( 'Could not update %s!</em> WPCACHEHOME must be set in config file.', 'wp-super-cache' ), $global_config_file ) . "</h4></div>";
+			return false;
+		}
 	}
 	$ret = true;
 


### PR DESCRIPTION
It's not enough to check if WPCACHEHOME is in wp-config.php. I must also
check if it's either blank or set to the wrong path. If so then the
config file has to be updated.
Ref:
https://wordpress.org/support/topic/warning-wp-super-cache-caching-was-broken-but-has-been-fixed-3/