### PR TITLE
Hide get_post() warnings if no post found.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2753,7 +2753,7 @@ function wp_cache_clear_cache( $blog_id = 0 ) {
 }
 
 function wpsc_delete_post_archives( $post ) {
-	$post = get_post( $post );
+	$post = @get_post( $post );
 	if ( ! is_object( $post ) ) {
 		return;
 	}


### PR DESCRIPTION
Ref: https://wordpress.org/support/topic/some-errors-19/