### PR TITLE
Only allow the debug log to be viewed through the viewer.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1014,13 +1014,7 @@ function wpsc_create_debug_log( $filename = '', $username = '' ) {
 		$wp_cache_debug_username = wpsc_debug_username();
 	}
 
-	$msg = '
-if ( !isset( $_SERVER[ "PHP_AUTH_USER" ] ) || ( $_SERVER[ "PHP_AUTH_USER" ] != "' . $wp_cache_debug_username . '" && $_SERVER[ "PHP_AUTH_PW" ] != "' . $wp_cache_debug_username . '" ) ) {
-	header( "WWW-Authenticate: Basic realm=\"WP-Super-Cache Debug Log\"" );
-	header( $_SERVER[ "SERVER_PROTOCOL" ] . " 401 Unauthorized" );
-	echo "You must login to view the debug log";
-	exit;
-}' . PHP_EOL;
+	$msg = 'die( "Please use the viewer" );' . PHP_EOL;
 	$fp = fopen( $cache_path . $wp_cache_debug_log, 'w' );
 	if ( $fp ) {
 		fwrite( $fp, '<' . "?php\n" );
@@ -1031,6 +1025,15 @@ if ( !isset( $_SERVER[ "PHP_AUTH_USER" ] ) || ( $_SERVER[ "PHP_AUTH_USER" ] != "
 		wp_cache_setting( 'wp_cache_debug_log', $wp_cache_debug_log );
 		wp_cache_setting( 'wp_cache_debug_username', $wp_cache_debug_username );
 	}
+
+	$msg = '
+if ( !isset( $_SERVER[ "PHP_AUTH_USER" ] ) || ( $_SERVER[ "PHP_AUTH_USER" ] != "' . $wp_cache_debug_username . '" && $_SERVER[ "PHP_AUTH_PW" ] != "' . $wp_cache_debug_username . '" ) ) {
+	header( "WWW-Authenticate: Basic realm=\"WP-Super-Cache Debug Log\"" );
+	header( $_SERVER[ "SERVER_PROTOCOL" ] . " 401 Unauthorized" );
+	echo "You must login to view the debug log";
+	exit;
+}' . PHP_EOL;
+
 	$fp = fopen( $cache_path . 'view_' . $wp_cache_debug_log, 'w' );
 	if ( $fp ) {
 		fwrite( $fp, '<' . "?php" . PHP_EOL );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2131,11 +2131,10 @@ function wp_cache_debug_settings() {
 		extract( wpsc_create_debug_log() ); // $wp_cache_debug_log, $wp_cache_debug_username
 	}
 	$log_file_link = "<a href='" . site_url( str_replace( ABSPATH, '', "{$cache_path}view_{$wp_cache_debug_log}" ) ) . "'>$wp_cache_debug_log</a>";
-	$raw_log_file_link = "<a href='" . site_url( str_replace( ABSPATH, '', "{$cache_path}{$wp_cache_debug_log}" ) ) . "'>" . __( 'RAW', 'wp-super-cache' ) . "</a>";
 	if ( $wp_super_cache_debug == 1 ) {
-		echo "<p>" . sprintf( __( 'Currently logging to: %s (%s)', 'wp-super-cache' ), $log_file_link, $raw_log_file_link ) . "</p>";
+		echo "<p>" . sprintf( __( 'Currently logging to: %s', 'wp-super-cache' ), $log_file_link ) . "</p>";
 	} else {
-		echo "<p>" . sprintf( __( 'Last Logged to: %s (%s)', 'wp-super-cache' ), $log_file_link, $raw_log_file_link ) . "</p>";
+		echo "<p>" . sprintf( __( 'Last Logged to: %s', 'wp-super-cache' ), $log_file_link ) . "</p>";
 	}
 	echo "<p>" . sprintf( __( 'Username/Password: %s', 'wp-super-cache' ), $wp_cache_debug_username ) . "</p>";
 


### PR DESCRIPTION
The debug log can be viewed through a viewer that allows the user to find exactly what they want from the log. The RAW output was added just because that was the old way of viewing it but it's time to retire it.

Someone can still view the raw file in an ssh session or downloading the file.