### PR TITLE
Added "wpsc_cdn_urls" filter to modify the URLs used to rewrite URLs

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -202,6 +202,8 @@ function scossdl_off_filter( $content ) {
 		$ossdl_arr_of_cnames = array_merge( array( $ossdl_off_cdn_url ), (array) $ossdl_arr_of_cnames );
 	}
 
+	$ossdl_arr_of_cnames = apply_filters( 'wpsc_cdn_urls', $ossdl_arr_of_cnames );
+
 	$dirs  = scossdl_off_additional_directories();
 	$regex = '`(?<=[(\"\'])' . preg_quote( $ossdl_off_blog_url, '`' ) . '/(?:((?:' . $dirs . ')[^\"\')]+)|([^/\"\']+\.[^/\"\')]+))(?=[\"\')])`';
 	return preg_replace_callback( $regex, 'scossdl_off_rewriter', $content );


### PR DESCRIPTION
This filter will allow other plugins to modify the URLs used to rewrite
URLs in the html by the CDN feature.

Prompted by
https://wordpress.org/support/topic/wp-super-cache-doesnt-offer-cdn-support-for-multiple-domain-wpml-installations/