### PR TITLE
Move these checks below OB so CDN works again.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1326,20 +1326,6 @@ function wp_cache_phase2() {
 		header( 'Vary: Accept-Encoding, Cookie' );
 	}
 
-	if ( wpsc_is_caching_user_disabled() ) {
-		wp_cache_debug( 'wp_cache_phase2: Caching disabled for known user! Exit.' );
-		define( 'WPSCSHUTDOWNMESSAGE', __( 'Caching disabled for known user. User logged in or cookie found.', 'wp-super-cache' ) );
-		add_action( 'wp_footer', 'wpsc_shutdown_message' );
-		return false;
-	}
-
-	if ( wp_cache_user_agent_is_rejected() ) {
-		define( 'WPSCSHUTDOWNMESSAGE', __( 'Caching disabled because user agent was rejected.', 'wp-super-cache' ) );
-		wp_cache_debug( 'wp_cache_phase2: No caching to do as user agent rejected.' );
-		add_action( 'wp_footer', 'wpsc_shutdown_message' );
-		return false;
-	}
-
 	ob_start( 'wp_cache_ob_callback' );
 	wp_cache_debug( 'Created output buffer', 4 );
 
@@ -1858,6 +1844,12 @@ function wp_cache_ob_callback( $buffer ) {
 		$cache_this_page = false;
 	} elseif ( empty( $wp_super_cache_query ) && !empty( $buffer ) && apply_filters( 'wpsc_only_cache_known_pages', 1 ) ) {
 		wp_cache_debug( 'wp_cache_ob_callback: wp_super_cache_query is empty. Not caching unknown page type. Return 0 to the wpsc_only_cache_known_pages filter to cache this page.' );
+		$cache_this_page = false;
+	} elseif ( wpsc_is_caching_user_disabled() ) {
+		wp_cache_debug( 'wp_cache_ob_callback: Caching disabled for known user. User logged in or cookie found.' );
+		$cache_this_page = false;
+	} elseif ( wp_cache_user_agent_is_rejected() ) {
+		wp_cache_debug( 'wp_cache_ob_callback: Caching disabled because user agent was rejected.' );
 		$cache_this_page = false;
 	}
 


### PR DESCRIPTION
Those checks stopped the output buffer working which stopped the CDN
function working for logged in/known users when caching was disabled for
them.
Moving them down here allows the OB to work and the CDN code runs too.

Maybe fixes #696 