### PR TITLE
Add wp_cache_cleared action to prune_super_cache

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2402,6 +2402,7 @@ function prune_super_cache( $directory, $force = false, $rename = false ) {
 				}
 			}
 			closedir($dh);
+			do_action( 'wp_cache_cleared' );
 		}
 	} elseif( is_file($directory) && ($force || @filemtime( $directory ) + $cache_max_time <= $now ) ) {
 		$oktodelete = true;


### PR DESCRIPTION
The wp_cache_cleared action was missing for the prune_super_cache function. This enables a function to be hooked after the cache is cleared when a post is published / edited / trashed etc.

Fix for ticket #713 