### PR TITLE
Add filter to wp-config.php WP_CACHE setting; Close #715

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2662,7 +2662,7 @@ function wp_cache_check_global_config() {
 		$global_config_file = dirname( ABSPATH ) . '/wp-config.php';
 	}
 
-	$line = 'define(\'WP_CACHE\', true);';
+	$line = apply_filters('supercache_wp_config_line', 'define(\'WP_CACHE\', true);');
 	if (
 		! is_writeable_ACLSafe( $global_config_file ) ||
 		! wp_cache_replace_line( 'define *\( *\'WP_CACHE\'', $line, $global_config_file )


### PR DESCRIPTION
This is a simple solution for #715. It allows developers to customize the line that gets written to `wp-config.php`, thus allow for conditional caching (for example, disabling caching when using IE).

I tested this, and it gets added and removed correctly even when customized with a filter in a theme, so I believe this should work without any consequences, but please do let me know if I'm missing something obvious.