### PR TITLE
Improve wording of file list headers

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2877,7 +2877,7 @@ function wp_cache_files() {
 		echo "<li>" . sprintf( __( '%s Expired Pages', 'wp-super-cache' ), $cache_stats[ 'supercache' ][ 'expired' ] ) . "</li></ul>";
 		if ( $valid_nonce && array_key_exists('listfiles', $_GET) && isset( $_GET[ 'listfiles' ] ) ) {
 			echo "<div style='padding: 10px; border: 1px solid #333; height: 400px; width: 90%; overflow: auto'>";
-			$cache_description = array( 'supercache' => __( 'Super Cached Files', 'wp-super-cache' ), 'wpcache' => __( 'Full Cache Files', 'wp-super-cache' ) );
+			$cache_description = array( 'supercache' => __( 'WP-Super-Cached', 'wp-super-cache' ), 'wpcache' => __( 'WP-Cached', 'wp-super-cache' ) );
 			foreach( $cache_stats as $type => $details ) {
 				if ( is_array( $details ) == false )
 					continue;


### PR DESCRIPTION
Hello! A very simple PR here.

The file lists under the Contents tab had headings that ended in 2x the necessary "Files":

<img width="232" alt="Screen Shot 2019-12-05 at 8 56 02 PM" src="https://user-images.githubusercontent.com/1703673/70289098-b90c8380-17a1-11ea-85e3-a56271e361bd.png">

I removed the word from both strings since "Files" already being appended in line 2886.

While I was there, I changed the wording to match the two categories right above it, from "Super Cached" to "WP-Super-Cached" and "Full Cached" to "WP-Cached". I can revert those to the old wording if needed.

Thanks!