### PR TITLE
Fix plugin for usage with Debian wordpress package

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2567,8 +2567,12 @@ function wp_cache_create_advanced_cache() {
 	global $wpsc_advanced_cache_filename, $wpsc_advanced_cache_dist_filename;
 	if ( file_exists( ABSPATH . 'wp-config.php') ) {
 		$global_config_file = ABSPATH . 'wp-config.php';
-	} else {
+	} else if (file_exists(dirname(ABSPATH) . '/wp-config.php')) {
 		$global_config_file = dirname(ABSPATH) . '/wp-config.php';
+	} else if (defined('DEBIAN_FILE')) {
+		$global_config_file = DEBIAN_FILE;
+	} else {
+		die('Cannot locate wp-config.php');
 	}
 
 	$line = 'define( \'WPCACHEHOME\', \'' . dirname( __FILE__ ) . '/\' );';

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2569,7 +2569,7 @@ function wp_cache_create_advanced_cache() {
 		$global_config_file = ABSPATH . 'wp-config.php';
 	} elseif ( file_exists( dirname( ABSPATH ) . '/wp-config.php' ) ) {
 		$global_config_file = dirname( ABSPATH ) . '/wp-config.php';
-	} elseif ( defined( 'DEBIAN_FILE' ) ) {
+	} elseif ( defined( 'DEBIAN_FILE' ) && file_exists( DEBIAN_FILE ) ) {
 		$global_config_file = DEBIAN_FILE;
 	} else {
 		die('Cannot locate wp-config.php');

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2567,9 +2567,9 @@ function wp_cache_create_advanced_cache() {
 	global $wpsc_advanced_cache_filename, $wpsc_advanced_cache_dist_filename;
 	if ( file_exists( ABSPATH . 'wp-config.php') ) {
 		$global_config_file = ABSPATH . 'wp-config.php';
-	} else if (file_exists(dirname(ABSPATH) . '/wp-config.php')) {
-		$global_config_file = dirname(ABSPATH) . '/wp-config.php';
-	} else if (defined('DEBIAN_FILE')) {
+	} elseif ( file_exists( dirname( ABSPATH ) . '/wp-config.php' ) ) {
+		$global_config_file = dirname( ABSPATH ) . '/wp-config.php';
+	} elseif ( defined( 'DEBIAN_FILE' ) ) {
 		$global_config_file = DEBIAN_FILE;
 	} else {
 		die('Cannot locate wp-config.php');


### PR DESCRIPTION
Debian packages wordpress in a way that a single wordpress instance can
be used to serve multiple websites.  The wp-config.php file is stored
in a well-known location: /etc/wordpress/config-$HOST.php as explained
in the [README.Debian] file.

The package defines DEBIAN_FILE as the filename of the configuration
file.  When it is defined, and if the wp-config.php was not found using
the "traditional" way, use it.

By default, this file is not writable by the application, adding the
following to it is enough to use the plugin:

```
define('WP_CACHE', true);
define('WPCACHEHOME', '/var/lib/wordpress/wp-content-xxxxx/plugins/wp-super-cache/');
```

[README.Debian]:https://salsa.debian.org/debian/wordpress/blob/master/debian/README.debian