### PR TITLE
Make config file path configurable

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -5,7 +5,11 @@ if ( ! function_exists( 'wp_cache_phase2' ) ) {
 }
 
 // error_reporting(E_ERROR | E_PARSE); // uncomment to debug this file!
-if ( ! @include WP_CONTENT_DIR . '/wp-cache-config.php' ) {
+if ( !defined( 'WPCACHECONFIGPATH' ) ) {
+  define( 'WPCACHECONFIGPATH', WP_CONTENT_DIR );
+} 
+
+if ( ! @include WPCACHECONFIGPATH . '/wp-cache-config.php' ) {
 	return false;
 }
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -43,7 +43,11 @@ if ( ! defined( 'PHP_VERSION_ID' ) ) {
 function wpsc_init() {
 	global $wp_cache_config_file, $wp_cache_config_file_sample, $wpsc_advanced_cache_dist_filename, $wp_cache_check_wp_config, $wpsc_advanced_cache_filename;
 
-	$wp_cache_config_file = WP_CONTENT_DIR . '/wp-cache-config.php';
+  if ( !defined( 'WPCACHECONFIGPATH' ) ) {
+    define( 'WPCACHECONFIGPATH', WP_CONTENT_DIR );
+  } 
+
+	$wp_cache_config_file = WPCACHECONFIGPATH . '/wp-cache-config.php';
 
 	if ( !defined( 'WPCACHEHOME' ) ) {
 		define( 'WPCACHEHOME', dirname( __FILE__ ) . '/' );
@@ -3803,16 +3807,16 @@ function wp_cache_disable_plugin( $delete_config_file = true ) {
 	$file_not_deleted = false;
 	wpsc_remove_advanced_cache();
 	if ( @file_exists( WP_CONTENT_DIR . "/advanced-cache.php" ) ) {
-		$file_not_deleted[] = 'advanced-cache.php';
+		$file_not_deleted[] = WP_CONTENT_DIR . '/advanced-cache.php';
 	}
-	if ( $delete_config_file && @file_exists( WP_CONTENT_DIR . "/wp-cache-config.php" ) ) {
-		if ( false == unlink( WP_CONTENT_DIR . "/wp-cache-config.php" ) )
-			$file_not_deleted[] = 'wp-cache-config.php';
+	if ( $delete_config_file && @file_exists( WPCACHECONFIGPATH . "/wp-cache-config.php" ) ) {
+		if ( false == unlink( WPCACHECONFIGPATH . "/wp-cache-config.php" ) )
+			$file_not_deleted[] = WPCACHECONFIGPATH . '/wp-cache-config.php';
 	}
 	if ( $file_not_deleted ) {
 		$msg = __( "Dear User,\n\nWP Super Cache was removed from your blog or deactivated but some files could\nnot be deleted.\n\n", 'wp-super-cache' );
-		foreach( (array)$file_not_deleted as $filename ) {
-			$msg .=  WP_CONTENT_DIR . "/{$filename}\n";
+		foreach( (array)$file_not_deleted as $path ) {
+			$msg .=  "{$path}\n";
 		}
 		$msg .= "\n";
 		$msg .= sprintf( __( "You should delete these files manually.\nYou may need to change the permissions of the files or parent directory.\nYou can read more about this in the Codex at\n%s\n\nThank you.", 'wp-super-cache' ), 'https://codex.wordpress.org/Changing_File_Permissions#About_Chmod' );


### PR DESCRIPTION
By default the `wp-cache-config.php` file is saved in the `wp-content` directory and deleted and newly created on every config change. That causes problems if the `wp-cache-config.php` file is a symlink (see Automattic/wp-super-cache#884). To create a better workaround, I added a constant `WPCACHECONFIGPATH`. Now one can set
```php
define( 'WPCACHECONFIGPATH', '/var/www/current/wp-content/cache-config' );
```
in `wp-config.php` and make the whole `cache-config` directory a symlink.
Since `WPCACHECONFIGPATH` is set to `WP_CONTENT_DIR` if it's not defined, there's no change in behavior unless explicitly set.