### PR TITLE
Ignore tracking parameters

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -109,7 +109,7 @@ if ( function_exists( 'add_filter' ) ) { // loaded since WordPress 4.6
 	add_filter( 'supercache_filename_str', 'wp_cache_check_mobile' );
 }
 
-$wp_cache_request_uri = $_SERVER['REQUEST_URI']; // Cache this in case any plugin modifies it.
+$wp_cache_request_uri = remove_tracking_params_from_uri($_SERVER['REQUEST_URI']); // Cache request URI and filter out tracking parameters
 
 if ( defined( 'DOING_CRON' ) ) {
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -46,7 +46,7 @@ function remove_tracking_params_from_uri($uri) {
 	$path = isset($parsedUrl['path']) ? $parsedUrl['path'] : '';
 	$query = !empty($query) ? '?'. http_build_query($query) : '';
 
-	return $parsedUrl['scheme']. '://'. $parsedUrl['host']. $path. $query;
+	return $parsedUrl['host']. $path. $query;
 }
 
 function wp_super_cache_init() {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -28,6 +28,27 @@ function get_wp_cache_key( $url = false ) {
 	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace('/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
 }
 
+function remove_tracking_params_from_uri($uri) {
+	$parsedUrl = parse_url($uri);
+	$query = array();
+
+	if (isset($parsedUrl['query'])) {
+		parse_str($parsedUrl['query'], $query);
+		$q_params_to_ignore = array(
+			'fbclid', 'ref', 'gclid', 'fb_source', 'mc_cid', 'mc_eid',
+			'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_expid',
+			'mtm_source', 'mtm_medium', 'mtm_campaign', 'mtm_keyword', 'mtm_content', 'mtm_cid', 'mtm_group', 'mtm_placement',
+		);
+		foreach($q_params_to_ignore as $param_name) {
+			unset($query[$param_name]);
+		}
+	}
+	$path = isset($parsedUrl['path']) ? $parsedUrl['path'] : '';
+	$query = !empty($query) ? '?'. http_build_query($query) : '';
+
+	return $parsedUrl['scheme']. '://'. $parsedUrl['host']. $path. $query;
+}
+
 function wp_super_cache_init() {
 	global $wp_cache_key, $key, $blogcacheid, $file_prefix, $blog_cache_dir, $meta_file, $cache_file, $cache_filename, $meta_pathname;
 


### PR DESCRIPTION
Filter out tracking parameters (from Facebook, Google, Matomo) to use cached page as if there were no tracking parameter.
Pretty much a copy/paste of what @markfinst suggested in his comment [here](https://github.com/Automattic/wp-super-cache/issues/712#issuecomment-814626300)

Temporary fix for #712

Optimal solution would be to have a user friendly way of editing the ignored parameters