### PR TITLE
Ignore tracking parameters for caching from external sites.

### DIFF
--- a/wp-cache-phase1.php
+++ b/wp-cache-phase1.php
@@ -116,7 +116,7 @@ if ( function_exists( 'add_filter' ) ) { // loaded since WordPress 4.6
 	add_filter( 'supercache_filename_str', 'wp_cache_check_mobile' );
 }
 
-$wp_cache_request_uri = $_SERVER['REQUEST_URI']; // Cache this in case any plugin modifies it.
+$wp_cache_request_uri = wpsc_remove_tracking_params_from_uri( $_SERVER['REQUEST_URI'] ); // Cache this in case any plugin modifies it and filter out tracking parameters.
 
 if ( defined( 'DOING_CRON' ) ) {
 	extract( wp_super_cache_init() ); // $key, $cache_filename, $meta_file, $cache_file, $meta_pathname

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -28,6 +28,32 @@ function get_wp_cache_key( $url = false ) {
 	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace('/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
 }
 
+function wpsc_remove_tracking_params_from_uri( $uri ) {
+	global $wpsc_tracking_parameters, $wpsc_ignore_tracking_parameters;
+
+	if ( ! isset( $wpsc_ignore_tracking_parameters ) || ! isset( $wpsc_ignore_tracking_parameters ) ) {
+		return $uri;
+	}
+
+	if ( ! $wpsc_ignore_tracking_parameters ) {
+		return $uri;
+	}
+
+	$parsed_url = parse_url( $uri );
+	$query      = array();
+
+	if ( isset( $parsed_url['query'] ) ) {
+		parse_str( $parsed_url['query'], $query );
+		foreach( $wpsc_tracking_parameters as $param_name ) {
+			unset( $query[$param_name] );
+		}
+	}
+	$path = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
+	$query = ! empty( $query ) ? '?' . http_build_query( $query ) : '';
+
+	return $path. $query;
+}
+
 function wp_super_cache_init() {
 	global $wp_cache_key, $key, $blogcacheid, $file_prefix, $blog_cache_dir, $meta_file, $cache_file, $cache_filename, $meta_pathname;
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -31,7 +31,7 @@ function get_wp_cache_key( $url = false ) {
 function wpsc_remove_tracking_params_from_uri( $uri ) {
 	global $wpsc_tracking_parameters, $wpsc_ignore_tracking_parameters;
 
-	if ( ! $wpsc_ignore_tracking_parameters ) {
+	if ( ! isset( $wpsc_ignore_tracking_parameters ) || ! $wpsc_ignore_tracking_parameters ) {
 		return $uri;
 	}
 
@@ -51,7 +51,11 @@ function wpsc_remove_tracking_params_from_uri( $uri ) {
 	$path = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
 	$query = ! empty( $query ) ? '?' . http_build_query( $query ) : '';
 
-	return $path. $query;
+	if ( $uri !== $path . $query ) {
+		wp_cache_debug( 'Removed tracking parameters from URL. Returning ' . $path . $query );
+	}
+
+	return $path . $query;
 }
 
 function wp_super_cache_init() {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -31,11 +31,11 @@ function get_wp_cache_key( $url = false ) {
 function wpsc_remove_tracking_params_from_uri( $uri ) {
 	global $wpsc_tracking_parameters, $wpsc_ignore_tracking_parameters;
 
-	if ( ! isset( $wpsc_ignore_tracking_parameters ) || ! isset( $wpsc_ignore_tracking_parameters ) ) {
+	if ( ! $wpsc_ignore_tracking_parameters ) {
 		return $uri;
 	}
 
-	if ( ! $wpsc_ignore_tracking_parameters ) {
+	if ( ! isset( $wpsc_tracking_parameters ) || empty( $wpsc_tracking_parameters ) ) {
 		return $uri;
 	}
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1194,6 +1194,8 @@ table.wpsc-settings-table {
 			wp_cache_edit_accepted();
 			echo '</fieldset>';
 
+			wpsc_edit_tracking_parameters();
+
 			wp_cache_edit_rejected_ua();
 
 			wp_lock_down();
@@ -1979,6 +1981,44 @@ function wp_cache_edit_rejected_pages() {
 	wp_nonce_field('wp-cache');
 	echo "</form>\n";
 
+}
+
+function wpsc_update_tracking_parameters() {
+	global $wpsc_tracking_parameters, $valid_nonce, $wp_cache_config_file;
+
+	if ( isset( $_POST['tracking_parameters'] ) && $valid_nonce ) {
+		$text = wp_cache_sanitize_value( str_replace( '\\\\', '\\', $_POST['tracking_parameters'] ), $wpsc_tracking_parameters );
+		wp_cache_replace_line( '^ *\$wpsc_tracking_parameters', "\$wpsc_tracking_parameters = $text;", $wp_cache_config_file );
+		wp_cache_setting( 'wpsc_ignore_tracking_parameters', isset( $_POST['wpsc_ignore_tracking_parameters'] ) ? 1 : 0 );
+	}
+}
+
+function wpsc_edit_tracking_parameters() {
+	global $wpsc_tracking_parameters, $wpsc_ignore_tracking_parameters;
+
+	$admin_url = admin_url( 'options-general.php?page=wpsupercache' );
+	wpsc_update_tracking_parameters();
+
+	if ( ! isset( $wpsc_tracking_parameters ) ) {
+		$wpsc_tracking_parameters = array( 'fbclid', 'ref', 'gclid', 'fb_source', 'mc_cid', 'mc_eid', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_expid', 'mtm_source', 'mtm_medium', 'mtm_campaign', 'mtm_keyword', 'mtm_content', 'mtm_cid', 'mtm_group', 'mtm_placement' );
+	}
+
+	if ( ! isset( $wpsc_ignore_tracking_parameters ) ) {
+		$wpsc_ignore_tracking_parameters = 0;
+	}
+
+	echo '<a name="trackingparameters"></a><fieldset class="options"><h4>' . __( 'Tracking Parameters', 'wp-super-cache' ) . '</h4>';
+	echo '<form name="edit_tracking_parameters" action="' . esc_url_raw( add_query_arg( 'tab', 'settings', $admin_url ) . '#trackingparameters' ) . '" method="post">';
+	echo "<p>" . __( 'Tracking parameters to ignore when caching. Visitors from Facebook, Twitter and elsewhere to your website will go to a URL with tracking parameters added. This setting allows the plugin to ignore those parameters and show an already cached page. Any actual tracking by Google Analytics or other Javascript based code should still work as the URL of the page is not modified.', 'wp-super-cache' ) . "</p>\n";
+	echo '<textarea name="tracking_parameters" cols="20" rows="10" style="width: 50%; font-size: 12px;" class="code">';
+	foreach ( $wpsc_tracking_parameters as $parameter) {
+		echo esc_html( $parameter ) . "\n";
+	}
+	echo '</textarea> ';
+	echo "<p><label><input type='checkbox' name='wpsc_ignore_tracking_parameters' value='1' " . checked( 1, $wpsc_ignore_tracking_parameters, false ) . " /> " . __( 'Enable', 'wp-super-cache' ) . "</label></p>";
+	echo '<div class="submit"><input class="button-primary" type="submit" ' . SUBMITDISABLED . 'value="' . __( 'Save', 'wp-super-cache' ) . '" /></div>';
+	wp_nonce_field('wp-cache');
+	echo "</form>\n";
 }
 
 function wp_cache_update_rejected_cookies() {


### PR DESCRIPTION
As suggested by @markfinst in #712 and made into a PR by @radex02 in
tracking parameters like utm_source when caching or serving a page.
The actual URL isn't modified so tracking by Google Analytics should be
unaffected.

Fixes #712