### PR TITLE
Stop intercept of updating config file in temporary file rename

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1265,7 +1265,7 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 		}
 	}
 
-	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], 'wpsc' );
+	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], md5( mt_rand( 0, 9999 ) ) );
 	if ( file_exists( $tmp_config_filename . '.php' ) ) {
 		unlink( $tmp_config_filename . '.php' );
 		if ( file_exists( $tmp_config_filename . '.php' ) ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1266,6 +1266,12 @@ function wp_cache_replace_line( $old, $new, $my_file ) {
 	}
 
 	$tmp_config_filename = tempnam( $GLOBALS['cache_path'], 'wpsc' );
+	if ( file_exists( $tmp_config_filename . '.php' ) ) {
+		unlink( $tmp_config_filename . '.php' );
+		if ( file_exists( $tmp_config_filename . '.php' ) ) {
+			die( __( 'WARNING: attempt to intercept updating of config file.', 'wp-super-cache' ) );
+		}
+	}
 	rename( $tmp_config_filename, $tmp_config_filename . ".php" );
 	$tmp_config_filename .= ".php";
 	wp_cache_debug( 'wp_cache_replace_line: writing to ' . $tmp_config_filename );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1142,7 +1142,9 @@ table.wpsc-settings-table {
 					<legend class="hidden">Cache Location</legend>
 					<input type='text' size=80 name='wp_cache_location' value='<?php echo esc_attr( $cache_path ); ?>' />
 					<p><?php printf( __( 'Change the location of your cache files. The default is WP_CONTENT_DIR . /cache/ which translates to %s.', 'wp-super-cache' ), WP_CONTENT_DIR . '/cache/' ); ?></p>
-					<ol><li><?php _e( 'You must give the full path to the directory.', 'wp-super-cache' ); ?></li>
+					<ol>
+						<li><?php _e( 'DO NOT USE A DIRECTORY OTHER USERS ON THIS SERVER CAN WRITE TO SUCH AS /tmp/. BEWARE OF USING DIRECTORIES THAT HAVE THE STICKY BIT SET.', 'wp-super-cache' ); ?></li>
+						<li><?php _e( 'You must give the full path to the directory.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'If the directory does not exist, it will be created. Please make sure your web server user has write access to the parent directory. The parent directory must exist.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'If the new cache directory does not exist, it will be created and the contents of the old cache directory will be moved there. Otherwise, the old cache directory will be left where it is.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'Submit a blank entry to set it to the default directory, WP_CONTENT_DIR . /cache/.', 'wp-super-cache' ); ?></li>

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1143,7 +1143,7 @@ table.wpsc-settings-table {
 					<input type='text' size=80 name='wp_cache_location' value='<?php echo esc_attr( $cache_path ); ?>' />
 					<p><?php printf( __( 'Change the location of your cache files. The default is WP_CONTENT_DIR . /cache/ which translates to %s.', 'wp-super-cache' ), WP_CONTENT_DIR . '/cache/' ); ?></p>
 					<ol>
-						<li><?php _e( 'DO NOT USE A DIRECTORY OTHER USERS ON THIS SERVER CAN WRITE TO SUCH AS /tmp/. BEWARE OF USING DIRECTORIES THAT HAVE THE STICKY BIT SET.', 'wp-super-cache' ); ?></li>
+						<li><?php _e( 'Warning: do not use a shared directory like /tmp/ where other users on this server can modify files. Your cache files could be modified to deface your website.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'You must give the full path to the directory.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'If the directory does not exist, it will be created. Please make sure your web server user has write access to the parent directory. The parent directory must exist.', 'wp-super-cache' ); ?></li>
 						<li><?php _e( 'If the new cache directory does not exist, it will be created and the contents of the old cache directory will be moved there. Otherwise, the old cache directory will be left where it is.', 'wp-super-cache' ); ?></li>


### PR DESCRIPTION
As reported in email exchange after #779 with @guyasyou. 

Over email we discussed this issue and there is a tiny chance of information being leaked. It only happens when a site administrator uses a directory that is shared among other untrusted users as their cache folder. 
This directory must also have the sticky bit set so that file ownership cannot change.

This attack would only be successful if an attacker can predict the filename of the temporary file used by the plugin when updating wp-config.php. The filename is generated by tempnam() . Before writing any data to the file it is renamed and ".php" appended to the filename. If an attacker has predicted the filename correctly the rename() will overwrite their file, but the sticky bit on the directory will ensure they can still read it. While it's not impossible to do this, it is not simple either.

Using a shared folder is also a bad idea because other users on the server could modify cached files and deface the pages of websites hosted on the server. The fact that I do not recall this ever being reported suggests that most users don't use a shared folder, or attackers haven't thought of doing this.

This patch checks if the .php file exists, tries to delete it and if that fails it will stop with a warning as this it is a clear sign of an attack in progress.
It also adds an informational warning to the advanced settings page warning users not to use a shared folder.