### PR TITLE
Normalise case for percent-encoded URLs to fix expert mode caching of Unicode URLs

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -686,6 +686,13 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		}
 	} else {
 		$uri = strtolower( $wp_cache_request_uri );
+		$uri = preg_replace_callback(
+			"/%[a-f0-9]{2}/",
+			function ( $matches ) {
+				return strtoupper( $matches[0] );
+			},
+			$uri
+		);
 	}
 	$uri = wpsc_deep_replace( array( '..', '\\', 'index.php', ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( "/(\?.*)?(#.*)?$/", '', $uri ) ) );
 	$hostname = $WPSC_HTTP_HOST;


### PR DESCRIPTION
Fixes issue #756.

Modern browsers submit percent encoded characters in uppercase.
wp-super-cache normalises cache URLs to lowercase. This means that
non-ASCII URLs will never be served by expert mode (i.e. Apache or nginx
rewrite based) caching and always fall through to PHP.

Fix by adding an additional filter to the URL which uppercases percent
escapes. This retains the advantages of normalisation but fixes expert
mode cache hits.

This is running on my WordPress server with no issues.