### PR TITLE
Cast the variable to avoid warnings.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -2047,7 +2047,7 @@ function wp_cache_edit_rejected_cookies() {
 	echo '<form name="wp_edit_rejected_cookies" action="' . esc_url_raw( add_query_arg( 'tab', 'settings', $admin_url ) . '#rejectcookies' ) . '" method="post">';
 	echo "<p>" . __( 'Do not cache pages when these cookies are set. Add the cookie names here, one per line. Matches on fragments, so "test" will match "WordPress_test_cookie". (Simple caching only)', 'wp-super-cache' ) . "</p>\n";
 	echo '<textarea name="wp_rejected_cookies" cols="40" rows="4" style="width: 50%; font-size: 12px;" class="code">';
-	foreach ( $wpsc_rejected_cookies as $file) {
+	foreach ( (array) $wpsc_rejected_cookies as $file) {
 		echo esc_html( $file ) . "\n";
 	}
 	echo '</textarea> ';


### PR DESCRIPTION
If $wpsc_rejected_cookies is not an array it will generate a warning, so we should cast it as an array to hide that warning.

Ref: https://wordpress.org/support/topic/php-error-in-debug-log-invalid-argument/