### PR TITLE
Only clear the cache from the current site, not the whole network.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -513,7 +513,8 @@ function admin_bar_delete_page() {
 
 	if ( $path ) {
 		if ( isset( $_GET['admin'] ) ) {
-			prune_super_cache( $path, true );
+			global $file_prefix;
+			wp_cache_clean_cache( $file_prefix );
 			wp_safe_redirect( admin_url( '/' ) );
 			exit;
 		}


### PR DESCRIPTION
The code would clear the entire cache directory which is probably not what you want when someone clicks "Delete Cache" on the admin bar of a site on a multisite network. 
This patch restricts it to the current site, not everything.