### PR TITLE
Don't reject bots. They "preload pages" too.

### DIFF
--- a/wp-cache-config-sample.php
+++ b/wp-cache-config-sample.php
@@ -21,7 +21,7 @@ $ossdlcdn = 0;
 $cache_acceptable_files = array( 'wp-comments-popup.php', 'wp-links-opml.php', 'wp-locations.php' );
 
 $cache_rejected_uri = array('wp-.*\\.php', 'index\\.php');
-$cache_rejected_user_agent = array ( 0 => 'bot', 1 => 'ia_archive', 2 => 'slurp', 3 => 'crawl', 4 => 'spider', 5 => 'Yandex' );
+$cache_rejected_user_agent = array();
 
 $cache_rebuild_files = 1;
 


### PR DESCRIPTION
Preloading seems to cause problems on some hosts and it's obviously a useful function so why not let the visiting bots do the job?
New installs of the plugin won't reject the bots any more by default.