### PR TITLE
Make sure this variable is passed to the template file too.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1052,6 +1052,7 @@ table.wpsc-settings-table {
 					'cache_schedule_interval',
 					'cache_time_interval',
 					'cache_gc_email_me',
+					'wp_cache_mobile_prefixes',
 					'wp_cache_preload_on'
 				)
 			);


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/php-warning-invalid-argument-supplied-for-foreach-45/#post-15311346