### PR TITLE
Add $cache_path to the easy template.

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -1077,6 +1077,7 @@ table.wpsc-settings-table {
 					'is_nginx'      => $is_nginx,
 					'wp_cache_mod_rewrite' => $wp_cache_mod_rewrite,
 					'valid_nonce' => $valid_nonce,
+					'cache_path'              => $cache_path,
 					'wp_super_cache_comments' => $wp_super_cache_comments,
 				)
 			);


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/%d0%bf%d0%be%d1%81%d0%bb%d0%b5-%d0%be%d0%b1%d0%bd%d0%be%d0%b2%d0%bb%d0%b5%d0%bd%d0%b8%d1%8f-%d1%83%d0%b2%d0%b5%d0%b4%d0%be%d0%bc%d0%bb%d0%b5%d0%bd%d0%b8%d1%8f-%d0%be%d0%b1-%d0%be%d1%88%d0%b8%d0%b1/#post-15312158