### PR TITLE
Fix link to log file in custom WordPress structure

### DIFF
--- a/partials/debug.php
+++ b/partials/debug.php
@@ -9,7 +9,7 @@ if ( ! isset( $wp_cache_debug_log ) || $wp_cache_debug_log == '' ) {
 	extract( wpsc_create_debug_log() ); // $wp_cache_debug_log, $wp_cache_debug_username
 }
 
-$log_file_link = "<a href='" . site_url( str_replace( ABSPATH, '', "{$cache_path}view_{$wp_cache_debug_log}?wp-admin=1&wp-json=1&filter=" ) ) . "'>$wp_cache_debug_log</a>";
+$log_file_link = "<a href='" . home_url( str_replace( $_SERVER['DOCUMENT_ROOT'], '', "{$cache_path}view_{$wp_cache_debug_log}?wp-admin=1&wp-json=1&filter=" ) ) . "'>$wp_cache_debug_log</a>";
 
 if ( $wp_super_cache_debug == 1 ) {
 	echo "<p>" . sprintf( __( 'Currently logging to: %s', 'wp-super-cache' ), $log_file_link ) . "</p>";


### PR DESCRIPTION
At the moment, the link to the wpsc log file is broken if WordPress is set up with a custom folder structure. This is what mine looks like:
```
.
├── content
│  ├── advanced-cache.php
│  ├── cache
│  ├── index.php
│  ├── plugins
│  ├── themes
│  ├── upgrade
│  ├── uploads
│  └── wp-cache-config.php
├── core
│  ├── license.txt
│  ├── readme.html
│  ├── wp-activate.php
│  ├── wp-admin
│  ├── wp-blog-header.php
│  ├── wp-comments-post.php
│  ├── wp-content
│  ├── wp-cron.php
│  ├── wp-includes
│  ├── wp-links-opml.php
│  ├── wp-load.php
│  ├── wp-login.php
│  ├── wp-mail.php
│  ├── wp-settings.php
│  ├── wp-signup.php
│  ├── wp-trackback.php
│  └── xmlrpc.php
├── index.php
└── wp-config.php
```
This pull request fixes the link to the log file so that if should resolve now in more scenarios.