### PR TITLE
Display the preloaded page using text rather html node

### DIFF
--- a/inc/preload-notification.js
+++ b/inc/preload-notification.js
@@ -12,7 +12,7 @@ function load_preload_status() {
 	jQuery.get({
 		url: wpsc_preload_ajax.preload_permalink_url + '?' + Math.random(),
 		success: function( response ) {
-			jQuery( '#preload_status' ).html( response );
+			jQuery( '#preload_status' ).text( response );
 		}
 	})
 }

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2328,7 +2328,7 @@ function wp_cache_get_ob(&$buffer) {
 			wp_cache_writers_exit();
 			wp_cache_debug( 'Warning! Not writing another page to front page cache.', 1 );
 			return $buffer;
-		} elseif ( filesize( $tmp_cache_filename ) == 0 ) {
+		} elseif ( @filesize( $tmp_cache_filename ) == 0 ) {
 			wp_cache_debug( "Warning! The file $tmp_cache_filename was empty. Did not rename to {$cache_fname}", 5 );
 			@unlink( $tmp_cache_filename );
 		} else {
@@ -2342,7 +2342,7 @@ function wp_cache_get_ob(&$buffer) {
 	}
 	if ( $gz ) {
 		fclose( $gz );
-		if ( filesize( $tmp_cache_filename . '.gz' ) == 0 ) {
+		if ( @filesize( $tmp_cache_filename . '.gz' ) == 0 ) {
 			wp_cache_debug( "Warning! The file {$tmp_cache_filename}.gz was empty. Did not rename to {$cache_fname}.gz", 5 );
 			@unlink( $tmp_cache_filename . '.gz' );
 		} else {


### PR DESCRIPTION
This string is supposed to only be a text string. No html, css or JS required so it's safer to use .text rather than .html

(It also has a minor change hiding warnings when creating a cache file, oops.)