### PR TITLE
Check this before closing it, just in case opening failed.

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3228,7 +3228,9 @@ function wp_cache_gc_cron() {
 	update_option( 'wpsupercache_gc_time', time() );
 	wp_cache_debug( "wp_cache_gc_cron: Set GC Flag. ($gc_flag)", 5 );
 	$fp = @fopen( $gc_flag, 'w' );
-	@fclose( $fp );
+	if ( $fp ) {
+		@fclose( $fp );
+	}
 
 	wp_cache_debug( 'Cache garbage collection.', 5 );
 


### PR DESCRIPTION
On the off chance that the $gc_flag isn't opened, we should check for that before closing it again.

ref:
https://wordpress.org/support/topic/fatal-error-triggered-php-8-1-2/