### PR TITLE
Fix up nonces and support AMP in "Delete Cache" button

### DIFF
--- a/inc/delete-cache-button.php
+++ b/inc/delete-cache-button.php
@@ -42,7 +42,10 @@ function wpsc_delete_cache_scripts() {
 		return;
 	}
 
-	if ( function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint() ) {
+	if (
+		is_plugin_active( 'amp/amp.php' ) ||
+		( function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint() )
+	) {
 		wp_cache_debug( 'AMP detected. Not loading Delete Cache button JavaScript.' );
 		return;
 	}

--- a/inc/delete-cache-button.php
+++ b/inc/delete-cache-button.php
@@ -21,7 +21,7 @@ function wpsc_admin_bar_render( $wp_admin_bar ) {
 					'id' => 'delete-cache',
 					'title' => __( 'Delete Cache', 'wp-super-cache' ),
 					'meta' => array( 'title' => __( 'Delete cache of the current page', 'wp-super-cache' ) ),
-					'href' => wp_nonce_url( admin_url( 'index.php?action=delcachepage&path=' . rawurlencode( $path ) ), 'delete-cache' )
+					'href' => wp_nonce_url( admin_url( 'index.php?action=delcachepage&path=' . rawurlencode( $path ) ), 'delete-cache-' . $path . '_0', 'nonce' )
 					) );
 	}
 
@@ -31,7 +31,7 @@ function wpsc_admin_bar_render( $wp_admin_bar ) {
 					'id' => 'delete-cache',
 					'title' => __( 'Delete Cache', 'wp-super-cache' ),
 					'meta' => array( 'title' => __( 'Delete Super Cache cached files', 'wp-super-cache' ) ),
-					'href' => wp_nonce_url( admin_url( 'index.php?admin=1&action=delcachepage&path=' . rawurlencode( trailingslashit( $path_to_home ) ) ), 'delete-cache' )
+					'href' => wp_nonce_url( admin_url( 'index.php?admin=1&action=delcachepage&path=' . rawurlencode( trailingslashit( $path_to_home ) ) ), 'delete-cache-' . trailingslashit( $path_to_home ) . '_1', 'nonce'  )
 					) );
 	}
 }
@@ -41,6 +41,12 @@ function wpsc_delete_cache_scripts() {
 	if ( ! is_user_logged_in() ) {
 		return;
 	}
+
+	if ( function_exists( 'ampforwp_is_amp_endpoint' ) && ampforwp_is_amp_endpoint() ) {
+		wp_cache_debug( 'AMP detected. Not loading Delete Cache button JavaScript.' );
+		return;
+	}
+
 	$path_to_home = rtrim( (string) parse_url( get_option( 'home' ), PHP_URL_PATH ), '/' );
 
 	wp_enqueue_script( 'delete-cache-button', plugins_url( '/delete-cache-button.js', __FILE__ ), array('jquery'), '1.0', 1 );
@@ -58,26 +64,73 @@ function wpsc_delete_cache_scripts() {
 		$path_to_home = '/';
 	}
 
-	$nonce = wp_create_nonce( 'delete-cache-' . rawurlencode( $path_to_home ) . '_' . $admin );
+	$nonce = wp_create_nonce( 'delete-cache-' . $path_to_home . '_' . $admin );
 	wp_localize_script( 'delete-cache-button', 'wpsc_ajax', array( 'ajax_url' => admin_url( 'admin-ajax.php' ), 'path' => $path_to_home, 'admin' => $admin, 'nonce' => $nonce ) );
 }
-add_action( 'wp_ajax_ajax-delete-cache', 'wpsc_admin_bar_delete_cache' );
+add_action( 'wp_ajax_ajax-delete-cache', 'wpsc_admin_bar_delete_cache_ajax' );
 add_action( 'wp_enqueue_scripts', 'wpsc_delete_cache_scripts' );
 add_action( 'admin_enqueue_scripts', 'wpsc_delete_cache_scripts' );
 
 /**
  * Delete cache for a specific page.
  */
-function wpsc_admin_bar_delete_cache() {
+function wpsc_admin_bar_delete_cache_ajax() {
 	// response output
 	header( "Content-Type: application/json" );
+	if ( ! wpsc_delete_cache_directory() ) {
+		if ( defined( 'WPSCDELETEERROR' ) ) {
+			return json_decode( constant( 'WPSCDELETEERROR' ) );
+		} else {
+			return json_decode( false );
+		}
+	}
+}
 
+function wpsc_admin_bar_delete_cache() {
+	$referer = wp_get_referer();
+
+	if ( ! isset( $_GET['admin'] ) ) {
+		$_GET['admin'] = 0;
+	}
+
+	foreach( array( 'path', 'nonce', 'admin' ) as $part ) {
+		if ( isset( $_GET[ $part ] ) ) {
+			$_POST[ $part ] = $_GET[ $part ];
+		}
+	}
+	wpsc_delete_cache_directory();
+
+	$req_path = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
+	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . $_POST['path'] . '_' . $_POST['admin'] ) : false;
+
+	if ( $valid_nonce && $referer && $req_path && ( false !== stripos( $referer, $req_path ) || 0 === stripos( $referer, wp_login_url() ) ) ) {
+		if ( $_POST['admin'] ) {
+			wp_safe_redirect( $referer );
+		} else {
+			wp_safe_redirect( esc_url_raw( home_url( $req_path ) ) );
+		}
+		exit;
+	} else {
+		die( "Oops. Problem with nonce. Please delete cached page from settings page." );
+	}
+}
+
+if ( 'delcachepage' === filter_input( INPUT_GET, 'action' ) ) {
+	add_action( 'admin_init', 'wpsc_admin_bar_delete_cache' );
+}
+
+function wpsc_delete_cache_directory() {
 	if ( ! current_user_can( 'delete_others_posts' ) ) {
-		return json_encode( false );
+		return false;
 	}
 
 	$req_path    = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
-	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . rawurlencode( $_POST['path'] ) . '_' . $_POST['admin'] ) : false;
+	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . $_POST['path'] . '_' . $_POST['admin'] ) : false;
+
+	if ( ! $valid_nonce ) {
+		wp_cache_debug( 'wpsc_delete_cache_directory: nonce was not valid' );
+		return false;
+	}
 
 	$path = $valid_nonce ? realpath( trailingslashit( get_supercache_dir() . str_replace( '..', '', preg_replace( '/:.*$/', '', $req_path ) ) ) ) : false;
 
@@ -91,17 +144,16 @@ function wpsc_admin_bar_delete_cache() {
 		$path           = trailingslashit( $path );
 		$supercachepath = realpath( get_supercache_dir() );
 
-		if ( false === wp_cache_confirm_delete( $path ) ||
-			0 !== strpos( $path, $supercachepath )
-		) {
+		if ( false === wp_cache_confirm_delete( $path ) || 0 !== strpos( $path, $supercachepath ) ) {
 			wp_cache_debug( 'Could not delete directory: ' . $path );
-			wp_die( json_encode( 'Could not delete directory' ) );
+			define( 'WPSCDELETEERROR', 'Could not delete directory' );
+			return false;
 		}
 
 		wp_cache_debug( 'Deleting cache files in directory: ' . $path );
 		wpsc_delete_files( $path );
 		return;
 	} else {
-		wp_cache_debug( 'Could not delete directory. It does not exist: ' . esc_attr( $_POST['path'] ) );
+		wp_cache_debug( 'wpsc_delete_cache_directory: Could not delete directory. It does not exist: ' . esc_attr( $_POST['path'] ) );
 	}
 }


### PR DESCRIPTION
Added a check for AMP using the AMPforWP plugin.

This patch also fixes up the nonces so they work when JS is disabled, as they would be when AMP is enabled.

https://wordpress.org/support/topic/amp-compatibility-issue-with-version-1-7-8/