### PR TITLE
Add this constant to disable the delete cache button

### DIFF
--- a/inc/delete-cache-button.php
+++ b/inc/delete-cache-button.php
@@ -1,4 +1,7 @@
 <?php
+if ( defined( 'WPSCDISABLEDELETEBUTTON' ) ) {
+	return;
+}
 
 /**
  * Adds "Delete Cache" button in WP Toolbar.


### PR DESCRIPTION
Define the constant WPSCDISABLEDELETEBUTTON to disable the delete cache button.

ref: https://wordpress.org/support/topic/option-to-disable-delete-cache-button-in-admin-bar/