### PR TITLE
Fixes the jQuery depreciated notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.github/.DS_Store

--- a/inc/delete-cache-button.js
+++ b/inc/delete-cache-button.js
@@ -1,6 +1,6 @@
 (function ($) {
 	$(document).ready(function () {
-		$('#wp-admin-bar-delete-cache').click(function () {
+		$('#wp-admin-bar-delete-cache').on("click",function () {
 			$('#wp-admin-bar-delete-cache').fadeOut('slow');
 			$.ajax({
 				type: "post",

--- a/partials/advanced.php
+++ b/partials/advanced.php
@@ -206,13 +206,13 @@ if ( $wp_cache_preload_on )
 
 echo "<script type='text/javascript'>";
 echo "jQuery(function () {
-	jQuery('#cache_interval_time').click(function () {
+	jQuery('#cache_interval_time').on('click',function () {
 		jQuery('#schedule_interval').attr('checked', true);
 	});
-	jQuery('#cache_scheduled_time').click(function () {
+	jQuery('#cache_scheduled_time').on('click',function () {
 		jQuery('#schedule_time').attr('checked', true);
 	});
-	jQuery('#cache_scheduled_select').click(function () {
+	jQuery('#cache_scheduled_select').on('click',function () {
 		jQuery('#schedule_time').attr('checked', true);
 	});
 	});";

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -802,7 +802,7 @@ function toggleLayer( whichLayer ) {
 // -->
 //Clicking header opens fieldset options
 jQuery(document).ready(function(){
-	jQuery("fieldset h4").css("cursor","pointer").click(function(){
+	jQuery("fieldset h4").css("cursor","pointer").on("click",function(){
 		jQuery(this).parent("fieldset").find("p,form,ul,blockquote").toggle("slow");
 	});
 });
@@ -1737,7 +1737,7 @@ function wp_cache_index_notice() {
 		<script  type='text/javascript'>
 		<!--
 			jQuery(document).ready(function(){
-				jQuery('#wpsc-dismiss').click(function() {
+				jQuery('#wpsc-dismiss').on("click",function() {
 						jQuery.ajax({
 							type: "post",url: "admin-ajax.php",data: { action: 'wpsc-index-dismiss', _ajax_nonce: '<?php echo wp_create_nonce( 'wpsc-index-dismiss' ); ?>' },
 							beforeSend: function() {jQuery("#wpsc-index-warning").fadeOut('slow');},


### PR DESCRIPTION
Resolves #826 `jQuery-fn-click()` shorthand is deprecated. 

### Description
Removes the jQuery notice which happens when the Delete Cache on the admin bar was clicked. 

<img width="615" alt="Screenshot 2022-07-20 at 13 37 35" src="https://user-images.githubusercontent.com/4077604/179983790-d34662e8-5072-41e2-a5ba-890b273011b6.png">

As well as tidied up in the other places in the code. 

### Testing instructions
In the master branch, click the delete cache button in the WP admin bar, switch to this branch check it still works and that we have no jQuery depreciated notices in the Console. 

