### PR TITLE
Prevent a deprecation notice in PHP 8.1 and later

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -28,6 +28,10 @@ function get_wp_cache_key( $url = false ) {
 	if ( ! $url ) {
 		$url = $wp_cache_request_uri;
 	}
+	// Prevent a PHP 8.1+ notice when passed into str_replace()
+	if ( is_null( $url ) ) {
+		$url = '';
+	}
 	$server_port = isset( $_SERVER['SERVER_PORT'] ) ? intval( $_SERVER['SERVER_PORT'] ) : 0;
 	return do_cacheaction( 'wp_cache_key', wp_cache_check_mobile( $WPSC_HTTP_HOST . $server_port . preg_replace( '/#.*$/', '', str_replace( '/index.php', '/', $url ) ) . $wp_cache_gzip_encoding . wp_cache_get_cookies_values() ) );
 }


### PR DESCRIPTION
If `$url` is `null`, set to `''` before passing to `str_replace()`. This is effectively the same behavior — we get to fix the notice without worrying about any potential bugs 😊

Fixes https://github.com/Automattic/jetpack/issues/28847