### PR TITLE
Fix link to Nginx instructions

### DIFF
--- a/partials/advanced.php
+++ b/partials/advanced.php
@@ -24,7 +24,7 @@ echo '<input type="hidden" name="action" value="scupdates" />';
 		<label><input type='radio' name='wp_cache_mod_rewrite' <?php if ( $wp_cache_mod_rewrite == 1 ) echo "checked"; ?> value='1'> <?php _e( '<acronym title="Use mod_rewrite to serve cached files">Expert</acronym>', 'wp-super-cache' ); ?></label><br />
 		<em><small class='description'><?php _e( 'Expert caching requires changes to important server files and may require manual intervention if enabled.', 'wp-super-cache' ); ?></small></em>
 		<?php if ( $is_nginx ) { ?>
-			<em><small class='description'><?php printf( __( 'Nginx rules can be found <a href="%s">here</a> but are not officially supported.', 'wp-super-cache' ), 'https://codex.wordpress.org/Nginx#WP_Super_Cache_Rules' ); ?></small></em>
+			<em><small class='description'><?php printf( __( 'Nginx rules can be found <a href="%s">here</a> but are not officially supported.', 'wp-super-cache' ), 'https://wordpress.org/documentation/article/nginx/#wp-super-cache-rules' ); ?></small></em>
 		<?php } ?>
 		</fieldset>
 	</td>


### PR DESCRIPTION
## Description

When used on Nginx, the Settings > Advanced page _Cache Delivery Method_ setting contains a link to Nginx configuration instructions, but the link is outdated.

![image](https://github.com/Automattic/wp-super-cache/assets/53293/b7871a15-c92e-46a8-bb6e-80e7fd76ac88)

The existing link points to a removed codex page, which contains a link to the right page... but the anchor is lost. This change corrects the link.

## Testing

### White box

Examine the old and new URLs and see what I mean.

### Black box

1. Check out this branch into a WP installation on Nginx.
2. Visit Settings > WP Super Cache > Advanced > Cache Delivery Method and click the "here" link (incidentally, it might be nice to not use a "here" link, they're bad for accessibility: perhaps we should have a sentence like "Nginx is not officially supported, but [documentation for configuring Nginx for static caching] is available"
3. See the right page