### PR TITLE
Type check $posts to prevent warning in gzip output stream

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3370,7 +3370,7 @@ function wp_cache_post_id() {
 	if ( $comment_post_ID > 0 ) {
 		return $comment_post_ID;
 	}
-	if ( is_singular() && ! empty( $posts ) ) {
+	if ( is_singular() && ! empty( $posts ) && is_array($posts) ) {
 		return $posts[0]->ID;
 	}
 	if ( isset( $_GET['p'] ) && $_GET['p'] > 0 ) {


### PR DESCRIPTION
We are happy users of wp-super-cache and have been for some time. Recently we discovered that sometimes pages would not render in Safari, but instead show "cannot decode raw data". The problem happens when visiting a page for that ought to be cached, but currently is not cached yet.

We traced the issue back to wp-super-cache, in combination with using the variable $posts in theme code to store a WP_Query (or anything that is not an array, for that matter). This causes wp_cache_post_id to show a warning which is added in plain text to the otherwise gzipped content. Safari can't decode the gzipped content (because of the extra content at the end) which causes the "cannot decode raw data" error. 

This pull request fixes the problem.