### PR TITLE
Check for null string before escaping

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -391,7 +391,7 @@ function wp_cache_postload() {
 	global $wp_cache_request_uri;
 
 	// have to sanitize here because formatting.php is loaded after wp_cache_request_uri is set
-	$wp_cache_request_uri = esc_url_raw( wp_unslash( $wp_cache_request_uri ) );
+	$wp_cache_request_uri = esc_url_raw( wp_unslash( $wp_cache_request_uri ? $wp_cache_request_uri : '' ) );
 
 	if ( ! $cache_enabled ) {
 		return true;


### PR DESCRIPTION
Running a CLI command like `wp cron event list` on PHP 8.1 produces a deprecation notice:

```
[07-Dec-2023 15:29:29 UTC] PHP Deprecated:  ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in wp-includes/formatting.php on line 4494
[07-Dec-2023 15:29:29 UTC] PHP Stack trace:
[07-Dec-2023 15:29:29 UTC] PHP   1. {main}() /usr/local/bin/wp:0
[07-Dec-2023 15:29:29 UTC] PHP   2. include() /usr/local/bin/wp:4
[07-Dec-2023 15:29:29 UTC] PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:20
[07-Dec-2023 15:29:29 UTC] PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:32
[07-Dec-2023 15:29:29 UTC] PHP   5. WP_CLI\Bootstrap\LaunchRunner->process($state = class WP_CLI\Bootstrap\BootstrapState { private $state = ['context_manager' => class WP_CLI\ContextManager { private $contexts = [...]; private $current_context = 'cli' }] }) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:83
[07-Dec-2023 15:29:29 UTC] PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28
[07-Dec-2023 15:29:29 UTC] PHP   7. WP_CLI\Runner->load_wordpress() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1282
[07-Dec-2023 15:29:29 UTC] PHP   8. require() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1363
[07-Dec-2023 15:29:29 UTC] PHP   9. wp_cache_postload() wp-settings.php:496
[07-Dec-2023 15:29:29 UTC] PHP  10. esc_url_raw($url = NULL, $protocols = *uninitialized*) wp-content/plugins/wp-super-cache/wp-cache-phase2.php:394
[07-Dec-2023 15:29:29 UTC] PHP  11. sanitize_url($url = NULL, $protocols = NULL) wp-includes/formatting.php:4602
[07-Dec-2023 15:29:29 UTC] PHP  12. esc_url($url = NULL, $protocols = NULL, $_context = 'db') wp-includes/formatting.php:4620
[07-Dec-2023 15:29:29 UTC] PHP  13. ltrim($string = NULL) wp-includes/formatting.php:4494
```

This PR detects if it's `null` and passes an empty string instead. I didn't use `??` because that requires PHP 7.