### PR TITLE
Fix str_starts_with() null deprecation in get_current_url_supercache_dir

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -854,8 +854,9 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 			}
 		} else {
 			$uri = str_replace( $site_url, '', $permalink );
-			if ( ! str_starts_with( $uri, $wp_cache_home_path ) ) {
-				$uri = rtrim( $wp_cache_home_path, '/' ) . $uri;
+			$home_path = $wp_cache_home_path ?? '';
+			if ( $home_path !== '' && ! str_starts_with( $uri, $home_path ) ) {
+				$uri = rtrim( $home_path, '/' ) . $uri;
 			}
 		}
 	} else {


### PR DESCRIPTION
## Summary

- Fixes a PHP 8.1+ deprecation warning: `str_starts_with(): Passing null to parameter #2 ($needle) of type string is deprecated` on line 857 of `wp-cache-phase2.php`
- The global `$wp_cache_home_path` can be null when not defined in the cache config, which gets passed directly to `str_starts_with()` and `rtrim()` as a null needle/characters parameter
- The fix coalesces `$wp_cache_home_path` to an empty string and skips the prefix check entirely when the home path is empty, avoiding both the deprecation and the semantically incorrect `rtrim(null, '/')` call

## Reproduction

1. Run any WP-CLI command or trigger a WP-Super-Cache operation on PHP 8.1+ where `$wp_cache_home_path` is not set in the cache config
2. Observe the deprecation notice:
   ```
   Deprecated: str_starts_with(): Passing null to parameter #2 ($needle) of type string is deprecated
   in /var/www/html/wp-content/plugins/wp-super-cache/wp-cache-phase2.php on line 857
   ```

## Changes

```diff
-  if ( ! str_starts_with( $uri, $wp_cache_home_path ) ) {
-    $uri = rtrim( $wp_cache_home_path, '/' ) . $uri;
+  $home_path = $wp_cache_home_path ?? '';
+  if ( $home_path !== '' && ! str_starts_with( $uri, $home_path ) ) {
+    $uri = rtrim( $home_path, '/' ) . $uri;
   }
```

## Notes

- Related but different from PR #848, which addressed a null `$wp_cache_request_uri` passed to `esc_url_raw()` on line 394
- This is a minimal, targeted fix with no behavioural change when `$wp_cache_home_path` is properly set

Made with [Cursor](https://cursor.com)