### PR TITLE
Fix: hide debug HTML comments in REST and Ajax responses

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2196,6 +2196,7 @@ function wpsc_skip_debug_output( $buffer ) {
 		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
 		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
 		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
+		( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) ||
 		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() );
 }
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2210,7 +2210,14 @@ function wp_cache_append_tag( &$buffer ) {
 		$msg = "Live page served on $timestamp";
 	}
 
-	if ( strpos( $buffer, '<html' ) === false ) {
+	// Don't output debug message if we aren't handling a normal HTML response.
+	if (
+		strpos( $buffer, '<html' ) === false ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
+		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
+		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() )
+	) {
 		wp_cache_debug( site_url( $_SERVER['REQUEST_URI'] ) . ' - ' . $msg );
 		return false;
 	}
@@ -2229,7 +2236,14 @@ function wp_cache_add_to_buffer( &$buffer, $text ) {
 		return false;
 	}
 
-	if ( strpos( $buffer, '<html' ) === false ) {
+	// Don't output debug message if we aren't handling a normal HTML response.
+	if (
+		strpos( $buffer, '<html' ) === false ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
+		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
+		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() )
+	) {
 		wp_cache_debug( site_url( $_SERVER['REQUEST_URI'] ) . ' - ' . $text );
 		return false;
 	}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2191,6 +2191,14 @@ function wp_cache_ob_callback( $buffer ) {
 	}
 }
 
+function wpsc_skip_debug_output( $buffer ) {
+	return strpos( $buffer, '<html' ) === false ||
+		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
+		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
+		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
+		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() );
+}
+
 function wp_cache_append_tag( &$buffer ) {
 	global $wp_cache_gmt_offset, $wp_super_cache_comments;
 	global $cache_enabled, $super_cache_enabled;
@@ -2210,14 +2218,7 @@ function wp_cache_append_tag( &$buffer ) {
 		$msg = "Live page served on $timestamp";
 	}
 
-	// Don't append debug HTML comments to non-HTML responses (REST, Ajax, etc.).
-	if (
-		strpos( $buffer, '<html' ) === false ||
-		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
-		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
-		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
-		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() )
-	) {
+	if ( wpsc_skip_debug_output( $buffer ) ) {
 		wp_cache_debug( site_url( $_SERVER['REQUEST_URI'] ) . ' - ' . $msg );
 		return false;
 	}
@@ -2236,14 +2237,7 @@ function wp_cache_add_to_buffer( &$buffer, $text ) {
 		return false;
 	}
 
-	// Don't append debug HTML comments to non-HTML responses (REST, Ajax, etc.).
-	if (
-		strpos( $buffer, '<html' ) === false ||
-		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
-		( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ||
-		( defined( 'WC_API_REQUEST' ) && WC_API_REQUEST ) ||
-		( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() )
-	) {
+	if ( wpsc_skip_debug_output( $buffer ) ) {
 		wp_cache_debug( site_url( $_SERVER['REQUEST_URI'] ) . ' - ' . $text );
 		return false;
 	}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2210,7 +2210,7 @@ function wp_cache_append_tag( &$buffer ) {
 		$msg = "Live page served on $timestamp";
 	}
 
-	// Don't output debug message if we aren't handling a normal HTML response.
+	// Don't append debug HTML comments to non-HTML responses (REST, Ajax, etc.).
 	if (
 		strpos( $buffer, '<html' ) === false ||
 		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||
@@ -2236,7 +2236,7 @@ function wp_cache_add_to_buffer( &$buffer, $text ) {
 		return false;
 	}
 
-	// Don't output debug message if we aren't handling a normal HTML response.
+	// Don't append debug HTML comments to non-HTML responses (REST, Ajax, etc.).
 	if (
 		strpos( $buffer, '<html' ) === false ||
 		( defined( 'REST_REQUEST' ) && REST_REQUEST ) ||


### PR DESCRIPTION
## Summary

- Prevents WP Super Cache from appending HTML debug comments (`<!-- ... -->`) to non-HTML responses such as REST API, Ajax, JSON API, and WooCommerce API requests.
- Adds checks for `REST_REQUEST`, `JSON_REQUEST`, `WC_API_REQUEST` constants and `wp_doing_ajax()` to both `wp_cache_append_tag()` and `wp_cache_add_to_buffer()`, bailing early when the response is not standard HTML.

Originally proposed by @jom in #436.

This is a manual cherry-pick of the changes from closed PR #436, adapted to the current codebase. See #436.

## Test plan

- [ ] Verify REST API responses (e.g., `/wp-json/wp/v2/posts`) do not contain `<!-- ... -->` debug comments when Super Cache debug mode is enabled.
- [ ] Verify Ajax responses (`admin-ajax.php`) do not contain HTML debug comments.
- [ ] Verify WooCommerce API responses do not contain HTML debug comments.
- [ ] Verify normal HTML page responses still include debug comments when debug mode is enabled.
- [ ] Verify that non-HTML responses (no `<html` tag) continue to be excluded as before.