### PR TITLE
Fix: use home_url() instead of site_url() in get_current_url_supercache_dir

### DIFF
--- a/plugins/multisite.php
+++ b/plugins/multisite.php
@@ -22,7 +22,7 @@ function wp_super_cache_blogs_field( $name, $blog_id ) {
 
 	$blog_id = (int) $blog_id;
 
-	if ( isset( $_GET['id'], $_GET['action'], $_GET['_wpnonce'] )
+	if ( isset( $_GET['id'] ) && isset( $_GET['action'] ) && isset( $_GET['_wpnonce'] )
 		&& $blog_id === filter_input( INPUT_GET, 'id', FILTER_VALIDATE_INT )
 		&& wp_verify_nonce( $_GET['_wpnonce'], 'wp-cache' . $blog_id )
 	) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -822,7 +822,7 @@ function get_supercache_dir( $blog_id = 0 ) {
 	return trailingslashit( apply_filters( 'wp_super_cache_supercachedir', $cache_path . 'supercache/' . trailingslashit( strtolower( preg_replace( '/:.*$/', '', str_replace( 'http://', '', str_replace( 'https://', '', $home ) ) ) ) ) ) );
 }
 function get_current_url_supercache_dir( $post_id = 0 ) {
-	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST, $wp_cache_home_path;
+	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST;
 	static $saved_supercache_dir = array();
 
 	if ( isset( $saved_supercache_dir[ $post_id ] ) ) {
@@ -831,14 +831,14 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 
 	$DONOTREMEMBER = 0;
 	if ( $post_id != 0 ) {
-		$site_url  = site_url();
+		$home_url  = home_url();
 		$permalink = get_permalink( $post_id );
-		if ( ! str_contains( $permalink, $site_url ) ) {
+		if ( ! str_contains( $permalink, $home_url ) ) {
 			/*
-			 * Sometimes site_url doesn't return the siteurl. See https://wordpress.org/support/topic/wp-super-cache-not-refreshing-post-after-comments-made
+			 * Sometimes home_url doesn't return the home url. See https://wordpress.org/support/topic/wp-super-cache-not-refreshing-post-after-comments-made
 			 */
 			$DONOTREMEMBER = 1;
-			wp_cache_debug( "get_current_url_supercache_dir: WARNING! site_url ($site_url) not found in permalink ($permalink).", 1 );
+			wp_cache_debug( "get_current_url_supercache_dir: WARNING! home_url ($home_url) not found in permalink ($permalink).", 1 );
 			if ( preg_match( '`^(https?:)?//([^/]+)(/.*)?$`i', $permalink, $matches ) ) {
 				if ( $WPSC_HTTP_HOST != $matches[2] ) {
 					wp_cache_debug( "get_current_url_supercache_dir: WARNING! SERVER_NAME ({$WPSC_HTTP_HOST}) not found in permalink ($permalink).", 1 );
@@ -853,10 +853,9 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 				$uri = '';
 			}
 		} else {
-			$uri       = str_replace( $site_url, '', $permalink );
-			$home_path = $wp_cache_home_path ?? '';
-			if ( $home_path !== '' && ! str_starts_with( $uri, $home_path ) ) {
-				$uri = rtrim( $home_path, '/' ) . $uri;
+			$uri = wp_parse_url( $permalink, PHP_URL_PATH );
+			if ( ! is_string( $uri ) ) {
+				$uri = '';
 			}
 		}
 	} else {
@@ -882,7 +881,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$dir = do_cacheaction( 'supercache_dir', $dir );
 	}
 	$dir = $cache_path . 'supercache/' . $dir . '/';
-	if ( is_array( $cached_direct_pages ) && in_array( $_SERVER['REQUEST_URI'], $cached_direct_pages ) ) {
+	if ( is_array( $cached_direct_pages ) && in_array( $_SERVER['REQUEST_URI'], $cached_direct_pages, true ) ) {
 		$dir = ABSPATH . $uri . '/';
 	}
 	$dir = str_replace( '..', '', str_replace( '//', '/', $dir ) );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -822,7 +822,7 @@ function get_supercache_dir( $blog_id = 0 ) {
 	return trailingslashit( apply_filters( 'wp_super_cache_supercachedir', $cache_path . 'supercache/' . trailingslashit( strtolower( preg_replace( '/:.*$/', '', str_replace( 'http://', '', str_replace( 'https://', '', $home ) ) ) ) ) ) );
 }
 function get_current_url_supercache_dir( $post_id = 0 ) {
-	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST;
+	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	static $saved_supercache_dir = array();
 
 	if ( isset( $saved_supercache_dir[ $post_id ] ) ) {
@@ -881,7 +881,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$dir = do_cacheaction( 'supercache_dir', $dir );
 	}
 	$dir = $cache_path . 'supercache/' . $dir . '/';
-	if ( is_array( $cached_direct_pages ) && in_array( $_SERVER['REQUEST_URI'], $cached_direct_pages, true ) ) {
+	if ( is_array( $cached_direct_pages ) && isset( $_SERVER['REQUEST_URI'] ) && in_array( $_SERVER['REQUEST_URI'], $cached_direct_pages, true ) ) {
 		$dir = ABSPATH . $uri . '/';
 	}
 	$dir = str_replace( '..', '', str_replace( '//', '/', $dir ) );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -834,7 +834,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$home_url  = home_url();
 		$permalink = get_permalink( $post_id );
 		if ( ! is_string( $permalink ) ) {
-			$DONOTREMEMBER = 1;
+			$DONOTREMEMBER = 1; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			wp_cache_debug( "get_current_url_supercache_dir: WARNING! get_permalink($post_id) did not return a valid string. Using front page.", 1 );
 			$uri = '';
 		} elseif ( ! str_contains( $permalink, $home_url ) ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -833,7 +833,11 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 	if ( $post_id != 0 ) {
 		$home_url  = home_url();
 		$permalink = get_permalink( $post_id );
-		if ( ! str_contains( $permalink, $home_url ) ) {
+		if ( ! is_string( $permalink ) ) {
+			$DONOTREMEMBER = 1;
+			wp_cache_debug( "get_current_url_supercache_dir: WARNING! get_permalink($post_id) did not return a valid string. Using front page.", 1 );
+			$uri = '';
+		} elseif ( ! str_contains( $permalink, $home_url ) ) {
 			/*
 			 * Sometimes home_url doesn't return the home url. See https://wordpress.org/support/topic/wp-super-cache-not-refreshing-post-after-comments-made
 			 */


### PR DESCRIPTION
## Summary

- Replace `site_url()` with `home_url()` in `get_current_url_supercache_dir()`, since permalinks are relative to the home URL, not the site URL (these differ when WordPress is installed in a subdirectory).
- Use `wp_parse_url( $permalink, PHP_URL_PATH )` to extract the URI path instead of string-replacing with `$wp_cache_home_path`, which doesn't work reliably in multisite installations.
- Add strict type checking to `in_array()` call.

Originally proposed by @stodorovic in #613.

See #613

## Test plan

- [ ] Verify cache directory resolution on a standard single-site install.
- [ ] Verify cache directory resolution on a multisite install.
- [ ] Verify cache directory resolution when WordPress is installed in a subdirectory (site URL differs from home URL).
- [ ] Confirm `get_current_url_supercache_dir()` returns the correct path for individual post IDs.