### PR TITLE
Fix CI followup: phpcs-changed and empty test suite

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,7 +22,15 @@ jobs:
       - name: Run PHPCS (changed lines only)
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            vendor/bin/phpcs-changed --git --git-base "${{ github.event.pull_request.base.sha }}"
+            BASE="${{ github.event.pull_request.base.sha }}"
           else
-            vendor/bin/phpcs-changed --git --git-base "${{ github.event.before }}"
+            BASE="${{ github.event.before }}"
           fi
+          FILES=$(git diff --name-only --diff-filter=d "$BASE" HEAD -- '*.php')
+          if [ -z "$FILES" ]; then
+            echo "No PHP files changed, skipping PHPCS."
+            exit 0
+          fi
+          echo "Changed PHP files:"
+          echo "$FILES"
+          echo "$FILES" | xargs vendor/bin/phpcs-changed --git --git-base "$BASE"

--- a/phpunit.11.xml.dist
+++ b/phpunit.11.xml.dist
@@ -12,7 +12,6 @@
 	displayDetailsOnTestsThatTriggerNotices="true"
 	displayDetailsOnTestsThatTriggerWarnings="true"
 	failOnDeprecation="true"
-	failOnEmptyTestSuite="true"
 	failOnPhpunitDeprecation="true"
 	failOnNotice="true"
 	failOnRisky="true"

--- a/phpunit.12.xml.dist
+++ b/phpunit.12.xml.dist
@@ -12,7 +12,6 @@
 	displayDetailsOnTestsThatTriggerNotices="true"
 	displayDetailsOnTestsThatTriggerWarnings="true"
 	failOnDeprecation="true"
-	failOnEmptyTestSuite="true"
 	failOnPhpunitDeprecation="true"
 	failOnNotice="true"
 	failOnRisky="true"


### PR DESCRIPTION
## Summary
Followup to #1020. Fixes two issues found in CI:

- `phpcs-changed` requires explicit file arguments; now passes the list of changed PHP files from git diff
- Removes `failOnEmptyTestSuite` from PHPUnit 11/12 configs since there are no test files yet (only `bootstrap.php`)
- Skips PHPCS entirely when no PHP files are changed

## Test plan
- [ ] PHPUnit passes on PHP 8.2, 8.3, 8.4, 8.5
- [ ] PHPCS passes when no new violations are introduced
- [ ] PHPCS skips gracefully when no PHP files are changed