### PR TITLE
Harden preload status AJAX endpoint

### DIFF
--- a/inc/preload-notification.php
+++ b/inc/preload-notification.php
@@ -20,6 +20,7 @@ function wpsc_preload_notification_scripts() {
 			'wpsc_preload_ajax',
 			array(
 				'ajax_url'       => admin_url( 'admin-ajax.php' ),
+				'nonce'          => wp_create_nonce( 'wpsc-get-preload-status' ),
 				'preload_status' => wpsc_get_preload_status( true ),
 			)
 		);

--- a/js/preload-notification.js
+++ b/js/preload-notification.js
@@ -28,6 +28,7 @@ jQuery( document ).ready( function () {
 				window.wpsc_preload_ajax.ajax_url,
 				{
 					action: 'wpsc_get_preload_status',
+					_ajax_nonce: window.wpsc_preload_ajax.nonce,
 				},
 				json => {
 					if ( ! json || ! json.success ) {

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3318,6 +3318,12 @@ function clear_post_supercache( $post_id ) {
  * Serves an AJAX endpoint to return the current state of the preload process.
  */
 function wpsc_ajax_get_preload_status() {
+	check_ajax_referer( 'wpsc-get-preload-status' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( null, 403 );
+	}
+
 	$preload_status = wpsc_get_preload_status( true );
 	wp_send_json_success( $preload_status, null, JSON_UNESCAPED_SLASHES );
 }


### PR DESCRIPTION
## Summary
- Minor hardening of the preload status AJAX handler.

## Test plan
- [ ] Load the Preload settings tab; confirm the status panel continues to update.