### PR TITLE
Disable caching for wp_die() error pages (#1015)

### DIFF
--- a/wp-cache.php
+++ b/wp-cache.php
@@ -157,6 +157,29 @@ function wp_super_cache_init_action() {
 }
 add_action( 'init', 'wp_super_cache_init_action' );
 
+/**
+ * Disable caching for pages rendered via wp_die().
+ *
+ * wp_die() is used to render error and interstitial pages (e.g. "Error
+ * establishing a database connection"); caching them causes the error to
+ * persist for subsequent visitors even after the underlying issue is resolved.
+ *
+ * @param callable $handler The registered wp_die handler, returned unchanged.
+ * @return callable
+ */
+function wpsc_wp_die_disable_cache( $handler ) {
+	/**
+	 * Filters whether to disable caching when wp_die() is invoked.
+	 *
+	 * @param bool $disable Whether to set DONOTCACHEPAGE. Default true.
+	 */
+	if ( apply_filters( 'wpsc_disable_cache_on_wp_die', true ) && ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	return $handler;
+}
+add_filter( 'wp_die_handler', 'wpsc_wp_die_disable_cache' );
+
 function wp_cache_set_home() {
 	global $wp_cache_is_home;
 	$wp_cache_is_home = ( is_front_page() || is_home() );

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -160,8 +160,8 @@ add_action( 'init', 'wp_super_cache_init_action' );
 /**
  * Disable caching for pages rendered via wp_die().
  *
- * wp_die() is used to render error and interstitial pages (e.g. "Error
- * establishing a database connection"); caching them causes the error to
+ * The function wp_die() is used to render error and interstitial pages (e.g.
+ * "Error establishing a database connection"); caching them causes the error to
  * persist for subsequent visitors even after the underlying issue is resolved.
  *
  * @param callable $handler The registered wp_die handler, returned unchanged.


### PR DESCRIPTION
## Summary
- Hook `wp_die_handler` to define `DONOTCACHEPAGE` whenever `wp_die()` is invoked, so error/interstitial pages (Redis/DB connection failures, permission errors, etc.) are never written to the cache
- Add a `wpsc_disable_cache_on_wp_die` filter to opt out for sites that intentionally render cacheable content via `wp_die()`

Fixes #1015

The existing `error_get_last()` check in the output-buffer callback doesn't catch `wp_die()` because it isn't a PHP error. W3 Total Cache takes the same approach ([Generic_Plugin.php#L896](https://github.com/BoldGrid/w3-total-cache/blob/a6d8e534ffcc3301994c4f43f9c69c4af761ec28/Generic_Plugin.php#L896)).

## Test plan
- [ ] Trigger `wp_die()` on a front-end request (e.g. stop Redis with Redis Object Cache active) and confirm no cache file is written for that URL
- [ ] After restoring the underlying service, confirm the next request renders and caches the real page
- [ ] Confirm `wp-cache.log` shows `DONOTCACHEPAGE defined. Caching disabled.` on the failing request
- [ ] Add a filter returning `false` for `wpsc_disable_cache_on_wp_die` and confirm `wp_die()` output is cached again (legacy behavior)