### PR TITLE
Release 3.1.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -262,6 +262,8 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 - Add WordPress.org Live Preview Blueprint.
 - Minimum WordPress version bumped to 6.8.
 - Device Detection: use an embedded version instead of the Composer dependency.
+- Fix: str_starts_with() null deprecation on PHP 8.1+.
+- Fix: handle array type for supercache_last_cached option.
 
 --------
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance, caching, wp-cache, wp-super-cache, cache
 Requires at least: 6.8
 Requires PHP: 7.4
 Tested up to: 6.9
-Stable tag: 3.0.3
+Stable tag: 3.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -255,16 +255,13 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 
 
 == Changelog ==
-### 3.0.3 - 2025-11-11
-#### Added
-- Tested up to WordPress 6.9.
-
-#### Changed
-- Update package dependencies.
-
-#### Fixed
-- Phan: Address PhanRedundantCondition, PhanRedundantArrayValuesCall, and PhanPluginRedundantAssignment violations.
-- Remove redundant code.
+### [3.1.0] - 2026-04-14
+- Disable caching for wp_die() error pages
+- Harden the plugin in various ways.
+- Fix: use fileperms() instead of stat() and fix escaping
+- Add WordPress.org Live Preview Blueprint.
+- Minimum WordPress version bumped to 6.8.
+- Device Detection: use an embedded version instead of the Composer dependency.
 
 --------
 

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 3.0.3
+ * Version: 3.1.0
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+


### PR DESCRIPTION
Prepares WP Super Cache 3.1.0 for release. Bumps the plugin version and updates the changelog.