### PR TITLE
Drop brackets from generated changelog heading

### DIFF
--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -81,7 +81,7 @@ else
 fi
 TODAY="$(date +%Y-%m-%d)"
 {
-	echo "### [$VERSION] - $TODAY"
+	echo "### $VERSION - $TODAY"
 	gh pr list \
 		--state merged \
 		--base trunk \


### PR DESCRIPTION
## Summary
- \`scripts/publish.sh\` extracts changelog notes via \`awk '^### ver( |$|-)'\`.
- The bracketed heading \`### [3.1.0] - 2026-04-14\` does not match that pattern, causing \`make publish\` to fail with "No changelog section found for 3.1.0 in readme.txt."
- Generate the heading without brackets so publish.sh can parse it, and so the format matches the pre-3.1.0 changelog entries in readme.txt.

## Test plan
- [ ] Run \`scripts/pre-build.sh X.Y.Z\` and confirm the generated changelog heading matches \`### X.Y.Z - YYYY-MM-DD\`.
- [ ] Confirm publish.sh's awk extraction finds the block.