### PR TITLE
Drop brackets from 3.1.0 changelog heading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -255,7 +255,7 @@ Your theme is probably responsive which means it resizes the page to suit whatev
 
 
 == Changelog ==
-### [3.1.0] - 2026-04-14
+### 3.1.0 - 2026-04-14
 - Disable caching for wp_die() error pages
 - Harden the plugin in various ways.
 - Fix: use fileperms() instead of stat() and fix escaping


### PR DESCRIPTION
## Summary
- \`make publish\` fails with "No changelog section found for 3.1.0 in readme.txt." because \`scripts/publish.sh\` extracts notes with \`awk '^### ver( |$|-)'\`, which does not match the bracketed heading.
- Drop the brackets so the heading matches the awk pattern and the pre-3.1.0 entries.

## Test plan
- [ ] Rebuild the plugin zip (\`make build\`) so the readme inside the archive matches.
- [ ] Confirm \`make publish\` finds the 3.1.0 changelog block.