### PR TITLE
Fix: add null check for comment in wp_cache_get_postid_from_comment()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3014,6 +3014,10 @@ function wp_cache_get_postid_from_comment( $comment_id, $status = 'NA' ) {
 	}
 
 	$comment = get_comment( $comment_id, ARRAY_A );
+	if ( ! $comment ) {
+		wp_cache_debug( "Comment not found; skipping cache update.", 4 );
+		return;
+	}
 	if ( $status != 'NA' ) {
 		$comment['old_comment_approved'] = $comment['comment_approved'];
 		$comment['comment_approved']     = $status;


### PR DESCRIPTION
Fixes #1014

get_comment() returns null when a comment has already been deleted by
the time the cache-clear routine runs. The existing code attempts to
access array offsets on that null value immediately after, which
triggers a PHP Warning on PHP 8.x.

This adds an early return right after get_comment() so the function
exits cleanly when the comment no longer exists, rather than
proceeding with a null value and generating noise in the error log.

Tested on PHP 8.3.8 / WordPress 6.7 / WP Super Cache 3.1.0.