### PR TITLE
Bump E2E workflow Node.js to 22

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: tests/e2e/pnpm-lock.yaml
 


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` with `version: latest` now pulls pnpm 11.1.3, which requires Node.js v22.13+ and imports `node:sqlite` (a built-in only available from Node 22).
- `actions/setup-node@v4` crashes with `ERR_UNKNOWN_BUILTIN_MODULE` while setting up the pnpm cache, failing every E2E run since #1044 (2026-05-08).
- Bumps `node-version` from `'20'` to `'22'` in `.github/workflows/e2e-tests.yml` to restore CI.

## Test plan

- [ ] E2E Tests check on this PR turns green.
- [ ] No regressions in other CI checks (PHPCS, PHPUnit) — they don't touch Node.