### PR TITLE
Tidy debug call in wp_cache_get_postid_from_comment()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3020,7 +3020,7 @@ function wp_cache_get_postid_from_comment( $comment_id, $status = 'NA' ) {
 
 	$comment = get_comment( $comment_id, ARRAY_A );
 	if ( ! $comment ) {
-		wp_cache_debug( 'Comment not found; skipping cache update.', 4 );
+		wp_cache_debug( 'Comment not found; skipping cache update.' );
 		return;
 	}
 	if ( $status != 'NA' ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3020,7 +3020,7 @@ function wp_cache_get_postid_from_comment( $comment_id, $status = 'NA' ) {
 
 	$comment = get_comment( $comment_id, ARRAY_A );
 	if ( ! $comment ) {
-		wp_cache_debug( "Comment not found; skipping cache update.", 4 );
+		wp_cache_debug( 'Comment not found; skipping cache update.', 4 );
 		return;
 	}
 	if ( $status != 'NA' ) {


### PR DESCRIPTION
Two small cleanups to the `wp_cache_debug()` call added in #1043:

1. **Single quotes** — phpcs (changed-lines lint) flagged the double-quoted string; it has no interpolation, so single quotes are correct.
2. **Drop vestigial level argument** — `wp_cache_debug( $message, $level = 1 )` declares `$level` but never uses it in the function body, so the trailing `4` did nothing.

Net: `wp_cache_debug( 'Comment not found; skipping cache update.' );`