### PR TITLE
Guard fclose() against false stream in supercache-only mode

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2418,7 +2418,9 @@ function wp_cache_get_ob( &$buffer ) {
 			if ( ! $fr2 ) {
 				wp_cache_debug( 'Error. Supercache could not write to ' . str_replace( ABSPATH, '', $tmp_cache_filename ), 1 );
 				wp_cache_add_to_buffer( $buffer, "File not cached! Super Cache Couldn't write to: " . str_replace( ABSPATH, '', $tmp_cache_filename ) );
-				@fclose( $fr );
+				if ( $fr ) {
+					fclose( $fr );
+				}
 				@unlink( $tmp_wpcache_filename );
 				wp_cache_writers_exit();
 				return wp_cache_maybe_dynamic( $buffer );
@@ -2430,7 +2432,9 @@ function wp_cache_get_ob( &$buffer ) {
 				if ( ! $gz ) {
 					wp_cache_debug( 'Error. Supercache could not write to ' . str_replace( ABSPATH, '', $tmp_cache_filename ) . '.gz', 1 );
 					wp_cache_add_to_buffer( $buffer, "File not cached! Super Cache Couldn't write to: " . str_replace( ABSPATH, '', $tmp_cache_filename ) . '.gz' );
-					@fclose( $fr );
+					if ( $fr ) {
+						fclose( $fr );
+					}
 					@unlink( $tmp_wpcache_filename );
 					@fclose( $fr2 );
 					@unlink( $tmp_cache_filename );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -2419,7 +2419,7 @@ function wp_cache_get_ob( &$buffer ) {
 				wp_cache_debug( 'Error. Supercache could not write to ' . str_replace( ABSPATH, '', $tmp_cache_filename ), 1 );
 				wp_cache_add_to_buffer( $buffer, "File not cached! Super Cache Couldn't write to: " . str_replace( ABSPATH, '', $tmp_cache_filename ) );
 				if ( $fr ) {
-					fclose( $fr );
+					fclose( $fr ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 				}
 				@unlink( $tmp_wpcache_filename );
 				wp_cache_writers_exit();
@@ -2433,7 +2433,7 @@ function wp_cache_get_ob( &$buffer ) {
 					wp_cache_debug( 'Error. Supercache could not write to ' . str_replace( ABSPATH, '', $tmp_cache_filename ) . '.gz', 1 );
 					wp_cache_add_to_buffer( $buffer, "File not cached! Super Cache Couldn't write to: " . str_replace( ABSPATH, '', $tmp_cache_filename ) . '.gz' );
 					if ( $fr ) {
-						fclose( $fr );
+						fclose( $fr ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 					}
 					@unlink( $tmp_wpcache_filename );
 					@fclose( $fr2 );


### PR DESCRIPTION
Fixes #1016.

In supercache-only mode `$fr` is `false` (the wp-cache file is never opened). When the supercache temp file fails to open, the error branches in `wp_cache_get_ob()` called `@fclose( $fr )` — i.e. `@fclose( false )`. On **PHP 8+ that is a `TypeError`, which `@` does not suppress**, so the request fatals (matches the report's `fclose(): Argument #1 ($stream) must be of type resource, false given`).

Fix: only call `fclose()` when the stream is actually open. Two call sites guarded; the adjacent `fclose( $fr2 )` is left as-is because `$fr2` is a valid resource on that branch.

Note: PR #1042 also contains this fix (bundled with the #1019 `$blog_id` cast and two redundant guards). This PR isolates just the #1016 fix.