### PR TITLE
Cast $blog_id to int in wp_cache_clear_cache()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3089,6 +3089,10 @@ function wp_cache_clear_cache_on_menu() {
 function wp_cache_clear_cache( $blog_id = 0 ) {
 	global $cache_path;
 
+	// Normalize non-integer callers (e.g. 'all', false) to 0 so they take the
+	// single-site path instead of reaching get_blog_option() via the blog branch.
+	$blog_id = (int) $blog_id;
+
 	if ( $blog_id == 0 ) {
 		wp_cache_debug( 'Clearing all cached files in wp_cache_clear_cache()', 4 );
 		prune_super_cache( $cache_path . 'supercache/', true );


### PR DESCRIPTION
Fixes #1019.

Some third-party callers invoke `wp_cache_clear_cache()` with a non-integer first argument (e.g. `wp_cache_clear_cache('all', false)`). That value flows into `get_supercache_dir()` -> `get_blog_option()`, a multisite-only function, which fatals on single-site installs.

Casting `$blog_id` to `int` normalizes `'all'`/`false` to `0`, so those calls take the single-site clearing path. Legitimate integer blog IDs are unaffected.

Note: PR #1042 also contains this cast (bundled with the #1016 `fclose` fix and two redundant guards). This PR isolates just the #1019 fix.