### PR TITLE
Fix: normalize $post_id and skip id 0 in post edit/change cache hooks

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -3287,6 +3287,16 @@ function wp_cache_post_edit( $post_id ) {
 	global $wp_cache_clear_on_post_edit, $cache_path, $blog_cache_dir;
 	static $last_post_edited = -1;
 
+	// Normalize $post_id to always be an integer (handles both int and WP_Post object)
+	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
+		$post_id = $post_id->ID;
+	}
+	$post_id = (int) $post_id;
+
+	if ( $post_id === 0 ) {
+		return $post_id;
+	}
+
 	if ( $post_id == $last_post_edited ) {
 		$action = current_filter();
 		wp_cache_debug( "wp_cache_post_edit({$action}): Already processed post $post_id.", 4 );
@@ -3359,6 +3369,16 @@ function wp_cache_post_id_gc( $post_id, $all = 'all' ) {
 function wp_cache_post_change( $post_id ) {
 	global $file_prefix, $cache_path, $blog_id, $super_cache_enabled, $blog_cache_dir, $wp_cache_refresh_single_only;
 	static $last_processed = -1;
+
+	// Normalize $post_id to always be an integer (handles both int and WP_Post object)
+	if ( is_object( $post_id ) && isset( $post_id->ID ) ) {
+		$post_id = $post_id->ID;
+	}
+	$post_id = (int) $post_id;
+
+	if ( $post_id === 0 ) {
+		return $post_id;
+	}
 
 	if ( $post_id == $last_processed ) {
 		$action = current_filter();


### PR DESCRIPTION
## What

Adds a defensive guard to the top of both `wp_cache_post_edit()` and `wp_cache_post_change()` in `wp-cache-phase2.php`:

1. If `$post_id` is a `WP_Post` object, unwrap it to `$post_id->ID`.
2. Cast to `int`.
3. Bail out early when the id is `0`.

## Why

Both functions assumed `$post_id` was always an integer. They are attached to `edit_post`, `delete_post`, `publish_post`, `clean_post_cache`, etc. — which pass an int in WP core, but third-party callers (and some edge paths) can pass a `WP_Post` object or a `0`.

The `=== 0` bail-out is the important half: a stray zero-id invalidation currently falls through and can clear the front-page / root `index.html` cache. This is a plausible contributor to the long-standing report in #959 ("Root index.html deleted unpredictably"). Skipping id 0 prevents that class of accidental front-page cache deletion, and normalizing objects to an int hardens the functions against `nav_menu_item`-style callers (cf. #931).

This is a precautionary hardening change — it doesn't alter behaviour for the normal integer-id path.

## Testing

- No behavioural change for valid integer post ids.
- Object input is unwrapped to its ID; `0` / non-numeric input now returns early instead of proceeding to cache clearing.

Refs #959

### Release Notes

- Fix: ignore a post ID of 0 when clearing the cache after a post edit, which could delete the front page cache unexpectedly.
