### PR TITLE
Exclude agent/dev docs from the release zip

### DIFF
--- a/scripts/exclude.lst
+++ b/scripts/exclude.lst
@@ -11,6 +11,9 @@ wp-super-cache/.phpcs.xml.dist
 wp-super-cache/w.org-assets
 wp-super-cache/.wp-env.json
 wp-super-cache/CHANGELOG.md
+wp-super-cache/AGENTS.md
+wp-super-cache/CLAUDE.md
+wp-super-cache/docs
 wp-super-cache/Makefile
 wp-super-cache/README.md
 wp-super-cache/build


### PR DESCRIPTION
`build/wp-super-cache.zip` was packaging AGENTS.md, CLAUDE.md, and docs/ (`docs/agents/`, `docs/adr/`). Fix: add them to `scripts/exclude.lst`.

Follow-up: #1075 converts the build to an allow-list so this can't recur (and drops two more files this deny-list still missed: `CONTEXT.md`, `phpunit-integration.9.xml.dist`).