### PR TITLE
Harden shared release tooling (sync with jetpack-crm)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Blocks direct pushes to the default branch. Land changes there via a pull
+# request instead. This fails faster and with a clearer message than a
+# server-side rejection.
+#
+# Install once per clone: `make install-hooks` (sets core.hooksPath to .githooks).
+# Override in a pinch:      `git push --no-verify`.
+#
+# NOTE: git hooks are local-only — they do not run on GitHub or in CI, so this
+# is a convenience guard, not enforcement.
+
+set -euo pipefail
+
+# Set to this repo's default branch (e.g. trunk or master).
+protected_branch="trunk"
+
+# stdin: <local ref> <local sha> <remote ref> <remote sha>, one line per ref.
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+	if [[ "${remote_ref}" == "refs/heads/${protected_branch}" ]]; then
+		echo "✋ Refusing to push directly to '${protected_branch}'. Open a pull request instead." >&2
+		echo "   (Override with 'git push --no-verify' if you really mean to.)" >&2
+		exit 1
+	fi
+done
+
+exit 0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' )
+    if: github.event.pull_request.merged == true && startsWith( github.head_ref, 'release/' ) && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     name: WPSC Release
     # The default GITHUB_TOKEN is read-only on repos that don't opt into
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Check out the PR's base branch (trunk) as a real local branch, not the
           # detached-HEAD merge ref, so create-release.mjs can `git push origin HEAD`.

--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -7,7 +7,7 @@ jobs:
   next-version-tags:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Check $$next-version$$ usage in added lines

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ install: ## Install PHP (Composer) and JS (npm) dependencies
 	composer install
 	npm install
 
+install-hooks: ## Install git hooks (fail-fast guard against direct pushes to the default branch)
+	git config core.hooksPath .githooks
+	@echo "Git hooks installed (core.hooksPath = .githooks)."
+
 up: $(WP_ENV_BIN) ## Start WordPress in Docker (http://localhost:8888, admin/password)
 	$(WP_ENV) start
 
@@ -83,4 +87,4 @@ i18n: ## Regenerate translation files (no-op: WPSC translations come from transl
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: install up down destroy logs cli wp seed unseed test test-integration lint lint-all lint-fix release build i18n help
+.PHONY: install install-hooks up down destroy logs cli wp seed unseed test test-integration lint lint-all lint-fix release build i18n help

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -47,6 +47,14 @@ if ( ! /^\d+(\.\d+)+(-(a|alpha|beta)([-.]?\d+)?)?$/.test( version ) ) {
 	process.exit( 1 );
 }
 
+// A release must be cut from a clean tree. The branch is created from the
+// current HEAD and `replaceNextVersionPlaceholder()` stages with `git add -u`,
+// which would sweep any modified tracked files into the release commit. Scope
+// the check to tracked changes: untracked files are never staged by the release
+// steps, so blocking on them would be a false positive. Fail fast, before the
+// confirmation prompt or any branch creation.
+assertCleanWorkingTree();
+
 const ghPrs = `gh pr list -R ${ cfg.repo } --state merged --base ${ BASE_BRANCH } --limit 500 --search "milestone:${ version }"`;
 
 // Confirm release through CLI.
@@ -97,6 +105,23 @@ function readFileContents( filepath ) {
 		return fs.readFileSync( filepath, 'utf8' );
 	} catch ( err ) {
 		throw new Error( `File (${ filepath }) could not be read.` );
+	}
+}
+
+/**
+ * Abort unless the working tree has no uncommitted changes to tracked files.
+ *
+ * A dirty tree is unsafe for a release: the release branch is cut from the
+ * current HEAD and `replaceNextVersionPlaceholder()` runs `git add -u`, which
+ * stages every modified tracked file — so stray edits would land in the release
+ * PR. Untracked files are excluded because no release step stages them.
+ */
+function assertCleanWorkingTree() {
+	const status = execSync( 'git status --porcelain --untracked-files=no' ).toString().trim();
+	if ( status ) {
+		console.log( chalk.bold.red( 'Error: the working tree has uncommitted changes to tracked files. Commit, stash or discard them before preparing a release.' ) );
+		console.log( status );
+		process.exit( 1 );
 	}
 }
 
@@ -322,6 +347,10 @@ function pushBranch() {
 /**
  * Revert the workspace to its original state.
  *
+ * Also deletes the release branch on the remote if it was already pushed (e.g.
+ * `createPR()` failed after `pushBranch()` succeeded) — otherwise the orphaned
+ * remote branch would block a retry, which recreates the same branch name.
+ *
  * @param {string} originalBranch The original branch name.
  * @param {string} branchToDelete The release branch to delete.
  */
@@ -330,4 +359,20 @@ function revertOnError( originalBranch, branchToDelete ) {
 	execSync( `git checkout . && git checkout ${ originalBranch }` );
 	console.log( `Deleting '${ branchToDelete }'....` );
 	execSync( `git branch -D ${ branchToDelete }` );
+
+	// Delete the remote branch too, but only if it exists. `git ls-remote
+	// --exit-code` exits non-zero when the branch isn't on the remote, so a
+	// throw here means "nothing to clean up".
+	try {
+		execSync( `git ls-remote --exit-code --heads ${ REMOTE } ${ branchToDelete }`, { stdio: 'ignore' } );
+	} catch {
+		return;
+	}
+	console.log( `Deleting '${ branchToDelete }' on ${ REMOTE }....` );
+	try {
+		execSync( `git push ${ REMOTE } --delete ${ branchToDelete }` );
+	} catch {
+		// Best-effort: don't let a failed remote cleanup mask the original error.
+		console.log( chalk.yellow( `Could not delete '${ branchToDelete }' on ${ REMOTE }; delete it manually before retrying.` ) );
+	}
 }


### PR DESCRIPTION
Syncs the shared release tooling with `Automattic/jetpack-crm` so the config-driven release scripts stay identical across the plugin family. Five hardening fixes:

1. **Clean-tree guard** (`scripts/prepare-release.mjs`): a new `assertCleanWorkingTree()` aborts before the confirmation prompt / branch creation if the working tree has uncommitted changes to tracked files. Otherwise `replaceNextVersionPlaceholder()`'s `git add -u` would sweep unrelated tracked edits into the release commit. Untracked files are excluded (no release step stages them).
2. **Remote-branch rollback cleanup** (`scripts/prepare-release.mjs`): `revertOnError()` now also deletes the release branch on the remote if it was already pushed (e.g. `createPR()` failed after `pushBranch()`), so a retry isn't blocked by an orphaned remote branch. Best-effort; a failed remote cleanup won't mask the original error.
3. **Fork-merge deploy guard** (`.github/workflows/create-release.yml`): the `deploy` job `if:` now also requires `github.event.pull_request.head.repo.full_name == github.repository`, so it only runs for same-repo (non-fork) release merges.
4. **SHA-pin actions** (`.github/workflows/create-release.yml`, `lint-next-version.yml`): pinned the two tag-referenced `actions/checkout` uses to their commit SHAs (supply-chain), keeping the original ref as a trailing comment. `checkout@v6.0.3` → `df4cb1c…` (matches jetpack-crm), `checkout@v4` → `11d5960…`. `setup-php` and `10up/action-wordpress-plugin-deploy` were already pinned.
5. **Pre-push hook + `make install-hooks`**: adds `.githooks/pre-push` (blocks direct pushes to `trunk`; override with `--no-verify`) and an `install-hooks` Makefile target that sets `core.hooksPath`. Local-only convenience guard, not CI enforcement.

Verified: `node --check scripts/prepare-release.mjs` passes; both workflows are valid YAML; no unpinned `uses:` tags remain in the two release workflows.
