### PR TITLE
Use --no-dev for the release workflow's composer install

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install JS dependencies
         run: npm install --no-audit --no-fund
       - name: Install PHP dependencies
-        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+        run: composer install --no-dev --no-ansi --no-interaction --prefer-dist --no-progress
       - name: Setup Git
         run: |
           git config user.name "WPSC Bot"


### PR DESCRIPTION
Same fix as Automattic/jetpack-crm#12, which failed for exactly this reason earlier today.

The deploy job pins PHP 7.4 and runs `composer install` with dev dependencies included. Several of those need PHP 8: `doctrine/instantiator` wants `^8.4`, `symfony/string` wants `>=8.4`, `symfony/console` `>=8.2`, `webmozart/assert` `^8.2` and `psr/log` `>=8.0`. None have a 7.x fallback, so composer refuses and the job dies before it reaches the build or the deploy.

This hasn't bitten yet because the release workflow has never actually run here. Every run so far shows as skipped, which is the `startsWith( head_ref, 'release/' )` guard doing its job on ordinary merges. The first real release would have hit it.

Worth noting `composer.lock` has no runtime packages at all, so `--no-dev` installs nothing and the step could be dropped entirely. I've left it in and matched the jetpack-crm fix instead, so the workflow stays identical across the plugins sharing this tooling.

WP Job Manager has the same missing flag but is not affected. Its dev tree locks PHPUnit at 9.6.34 and every package there has a 7.x alternative, so it resolves fine on 7.4.
