### PR TITLE
Encoded from unicode parts of URI should be uppercased in the both cases

### DIFF
--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Case-normalisation tests for get_current_url_supercache_dir().
+ *
+ * WordPress stores a non-ASCII post slug with LOWERCASE percent escapes:
+ * utf8_uri_encode() builds them with dechex(), and sanitize_title_with_dashes()
+ * lowercases the result afterwards. The supercache directory on disk, however,
+ * is written with those escapes UPPERCASED, because browsers send them that way
+ * and the mod_rewrite rules do a literal file test on the request path.
+ *
+ * Only the $post_id = 0 branch ever creates a supercache directory; the
+ * $post_id != 0 branch is used exclusively by the deletion paths. So whatever
+ * the $post_id = 0 branch produces is the shape the other branch has to match,
+ * or cache invalidation on post save looks for a directory that is not there.
+ * See PR #1080.
+ *
+ * Integration tier: needs get_permalink() and the rewrite rules, so these run
+ * under the real WordPress runtime.
+ *
+ * @package automattic/wp-super-cache
+ */
+class SupercacheDirCaseTest extends WP_UnitTestCase {
+
+	/**
+	 * Kazakh title from the original bug report, which sanitises to a slug full
+	 * of percent escapes.
+	 */
+	const NON_ASCII_TITLE = 'Ұlytau oblysy ortasha ajlyқ zhalaқy kөlemi';
+
+	public function set_up() {
+		parent::set_up();
+
+		$GLOBALS['cache_path']           = '/tmp/wpsc-supercache-dir-test/';
+		$GLOBALS['WPSC_HTTP_HOST']       = 'example.org';
+		$GLOBALS['wp_cache_home_path']   = '/';
+		$GLOBALS['wp_cache_request_uri'] = '/';
+		$GLOBALS['cached_direct_pages']  = array();
+
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	public function tear_down() {
+		$this->set_permalink_structure( '' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Publish a post and return its ID plus the path part of its permalink.
+	 *
+	 * @param string $title Post title.
+	 * @return array{0:int,1:string} Post ID and permalink path.
+	 */
+	private function publish( $title ) {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => $title,
+				'post_status' => 'publish',
+			)
+		);
+
+		return array( $post_id, (string) wp_parse_url( get_permalink( $post_id ), PHP_URL_PATH ) );
+	}
+
+	/**
+	 * The deletion branch has to land on the same directory the serving branch
+	 * creates. This is the regression from the bug report.
+	 *
+	 * Note: get_current_url_supercache_dir() memoises into a static keyed by
+	 * $post_id and never resets it, so key 0 may only be used by ONE test in the
+	 * suite. That test is this one.
+	 */
+	public function test_post_id_and_request_uri_branches_agree_for_non_ascii_slug() {
+		list( $post_id, $path ) = $this->publish( self::NON_ASCII_TITLE );
+
+		$this->assertStringContainsString( '%', $path, 'Expected the slug to be percent-encoded.' );
+
+		$from_post_id = get_current_url_supercache_dir( $post_id );
+
+		$GLOBALS['wp_cache_request_uri'] = $path;
+		$from_request_uri                = get_current_url_supercache_dir( 0 );
+
+		$this->assertSame(
+			$from_request_uri,
+			$from_post_id,
+			'The deletion branch must resolve to the directory the serving branch creates.'
+		);
+	}
+
+	/**
+	 * Every percent escape in the directory name is uppercased, whichever branch
+	 * produced it.
+	 */
+	public function test_percent_escapes_are_uppercased_on_the_post_id_branch() {
+		list( $post_id ) = $this->publish( self::NON_ASCII_TITLE );
+
+		$dir = get_current_url_supercache_dir( $post_id );
+
+		preg_match_all( '/%[0-9a-fA-F]{2}/', $dir, $matches );
+		$this->assertNotEmpty( $matches[0], "Expected percent escapes in {$dir}." );
+		$this->assertSame( array_map( 'strtoupper', $matches[0] ), $matches[0] );
+	}
+
+	/**
+	 * The rest of the path is lowercased on the post ID branch too. An install in
+	 * a subdirectory with a capital in it used to produce /Blog/... here while the
+	 * directory on disk was /blog/..., because inc/htaccess.php lowercases the
+	 * home root for the same convention.
+	 */
+	public function test_path_is_lowercased_on_the_post_id_branch() {
+		$GLOBALS['wp_cache_home_path'] = '/Blog/';
+
+		list( $post_id ) = $this->publish( 'Hello There' );
+
+		$dir = get_current_url_supercache_dir( $post_id );
+
+		$this->assertStringContainsString( '/blog/hello-there/', $dir );
+		$this->assertStringNotContainsString( '/Blog/', $dir );
+	}
+}

--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -4,9 +4,11 @@
  *
  * WordPress stores a non-ASCII post slug with LOWERCASE percent escapes:
  * utf8_uri_encode() builds them with dechex(), and sanitize_title_with_dashes()
- * lowercases the result afterwards. The supercache directory on disk, however,
- * is written with those escapes UPPERCASED, because browsers send them that way
- * and the mod_rewrite rules do a literal file test on the request path.
+ * lowercases the result afterwards. A URL encoder emits UPPERCASE escapes, so a
+ * visitor who follows a permalink and one who pastes the unicode URL send two
+ * different spellings of the same path. The plugin normalises both to uppercase
+ * so they land on one directory, the same way inc/htaccess.php lowercases the
+ * home root to keep that segment single-spelled.
  *
  * Only the $post_id = 0 branch ever creates a supercache directory; the
  * $post_id != 0 branch is used exclusively by the deletion paths. So whatever
@@ -27,21 +29,65 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	 */
 	const NON_ASCII_TITLE = 'Ұlytau oblysy ortasha ajlyқ zhalaқy kөlemi';
 
+	/**
+	 * Globals this class overwrites, snapshotted in set_up() and put back in
+	 * tear_down() so the values here do not leak into later test classes.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $saved_globals = array();
+
 	public function set_up() {
 		parent::set_up();
 
-		$GLOBALS['cache_path']           = '/tmp/wpsc-supercache-dir-test/';
-		$GLOBALS['WPSC_HTTP_HOST']       = 'example.org';
-		$GLOBALS['wp_cache_home_path']   = '/';
-		$GLOBALS['wp_cache_request_uri'] = '/';
-		$GLOBALS['cached_direct_pages']  = array();
+		$overrides = array(
+			'cache_path'           => '/tmp/wpsc-supercache-dir-test/',
+			'WPSC_HTTP_HOST'       => 'example.org',
+			'wp_cache_home_path'   => '/',
+			'wp_cache_request_uri' => '/',
+			'cached_direct_pages'  => array(),
+		);
+
+		$this->saved_globals = array();
+		foreach ( $overrides as $key => $value ) {
+			$this->saved_globals[ $key ] = array_key_exists( $key, $GLOBALS ) ? $GLOBALS[ $key ] : null;
+			$GLOBALS[ $key ]             = $value;
+		}
 
 		$this->set_permalink_structure( '/%postname%/' );
 	}
 
 	public function tear_down() {
+		foreach ( $this->saved_globals as $key => $value ) {
+			if ( null === $value ) {
+				unset( $GLOBALS[ $key ] );
+			} else {
+				$GLOBALS[ $key ] = $value;
+			}
+		}
+		$this->saved_globals = array();
+
 		$this->set_permalink_structure( '' );
 		parent::tear_down();
+	}
+
+	/**
+	 * Assert that nothing earlier in the process has already memoised $post_id = 0.
+	 *
+	 * get_current_url_supercache_dir() caches into a function static keyed by
+	 * $post_id and offers no way to reset it, so the first caller with key 0 wins
+	 * for the rest of the run. Without this check, a key poisoned by another test
+	 * class surfaces here as an unexplained directory mismatch.
+	 */
+	private function assertRequestUriBranchNotMemoised() {
+		$statics = ( new ReflectionFunction( 'get_current_url_supercache_dir' ) )->getStaticVariables();
+		$saved   = isset( $statics['saved_supercache_dir'] ) ? $statics['saved_supercache_dir'] : array();
+
+		$this->assertArrayNotHasKey(
+			0,
+			$saved,
+			'get_current_url_supercache_dir() has already memoised $post_id = 0 earlier in this process, so the request URI branch cannot be exercised here. Only one test per run may use key 0.'
+		);
 	}
 
 	/**
@@ -67,9 +113,12 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	 *
 	 * Note: get_current_url_supercache_dir() memoises into a static keyed by
 	 * $post_id and never resets it, so key 0 may only be used by ONE test in the
-	 * suite. That test is this one.
+	 * suite. That test is this one, and the precondition below says so out loud
+	 * if that ever stops being true.
 	 */
 	public function test_post_id_and_request_uri_branches_agree_for_non_ascii_slug() {
+		$this->assertRequestUriBranchNotMemoised();
+
 		list( $post_id, $path ) = $this->publish( self::NON_ASCII_TITLE );
 
 		$this->assertStringContainsString( '%', $path, 'Expected the slug to be percent-encoded.' );

--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -74,10 +74,10 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	/**
 	 * Assert that nothing earlier in the process has already memoised $post_id = 0.
 	 *
-	 * get_current_url_supercache_dir() caches into a function static keyed by
-	 * $post_id and offers no way to reset it, so the first caller with key 0 wins
-	 * for the rest of the run. Without this check, a key poisoned by another test
-	 * class surfaces here as an unexplained directory mismatch.
+	 * The function caches into a static keyed by $post_id and offers no way to
+	 * reset it, so the first caller with key 0 wins for the rest of the run.
+	 * Without this check, a key poisoned by another test class surfaces here as
+	 * an unexplained directory mismatch.
 	 */
 	private function assertRequestUriBranchNotMemoised() {
 		$statics = ( new ReflectionFunction( 'get_current_url_supercache_dir' ) )->getStaticVariables();

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -909,13 +909,6 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		}
 	} else {
 		$uri = strtolower( $wp_cache_request_uri );
-		$uri = preg_replace_callback(
-			'/%[a-f0-9]{2}/',
-			function ( $matches ) {
-				return strtoupper( $matches[0] );
-			},
-			$uri
-		);
 	}
 	$uri      = preg_replace_callback(
 		'/%[a-f0-9]{2}/',

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -917,6 +917,13 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 			$uri
 		);
 	}
+	$uri      = preg_replace_callback(
+		'/%[a-f0-9]{2}/',
+		function ( $matches ) {
+			return strtoupper( $matches[0] );
+		},
+		$uri
+	);
 	$uri      = wpsc_deep_replace( array( '..', '\\', 'index.php' ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( '/(\?.*)?(#.*)?$/', '', $uri ) ) );
 	$hostname = $WPSC_HTTP_HOST;
 	// Get hostname from wp options for wp-cron, wp-cli and similar requests.

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -908,8 +908,11 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 			}
 		}
 	} else {
-		$uri = strtolower( $wp_cache_request_uri );
+		$uri = $wp_cache_request_uri;
 	}
+
+	// Supercache directories are lowercase, with any percent escapes uppercased.
+	$uri      = strtolower( $uri );
 	$uri      = preg_replace_callback(
 		'/%[a-f0-9]{2}/',
 		function ( $matches ) {


### PR DESCRIPTION
When we have a post slug which contains unicode characters like this:

_ұlytau-oblysy-ortasha-ajlyқ-zhalaқy-kөlemi-bojynsha-elimizde-kөsh-bastady_

the plugin creates a directory which contains encoded parts instead of unicode:

_%D2%B1lytau-oblysy-ortasha-ajly%D2%9B-zhala%D2%9By-k%D3%A9lemi-bojynsha-elimizde-k%D3%A9sh-bastady_

the encoded parts are uppercased. It work when we read cache, but when we save the post, the plugin tries to remove the cache directory. It attempts to locate the directory with lowercased post slug but the directory isn't exist, so the cache couldn't be refreshed when the post saved.

Please review the fix for the issue.


### Release Notes
- Fix: clear the cache correctly when saving a post whose slug contains non-ASCII characters.
