### PR TITLE
Normalise URI case in every cache deletion path

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -51,6 +51,18 @@
 		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
 	</rule>
 
+	<!-- wpsc_sanitize_cache_path() is the sanitiser for request paths that name a
+	     supercache directory. sanitize_text_field() cannot be used there: it
+	     strips percent escapes, which is most of what such a path consists of
+	     (#1081). Teach PHPCS to recognise the replacement. -->
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customSanitizingFunctions" type="array">
+				<element value="wpsc_sanitize_cache_path"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
 		<properties>
 			<property name="ignoreUnusedRegexp" value="/^_/"/>

--- a/inc/delete-cache-button.php
+++ b/inc/delete-cache-button.php
@@ -105,7 +105,8 @@ function wpsc_admin_bar_delete_cache() {
 	}
 	wpsc_delete_cache_directory();
 
-	$req_path = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- the nonce is verified on the next line.
+	$req_path    = isset( $_POST['path'] ) ? wpsc_sanitize_cache_path( wp_unslash( $_POST['path'] ) ) : '';
 	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . $_POST['path'] . '_' . $_POST['admin'] ) : false;
 
 	if (
@@ -147,7 +148,8 @@ function wpsc_delete_cache_directory() {
 		return false;
 	}
 
-	$req_path    = isset( $_POST['path'] ) ? sanitize_text_field( stripslashes( $_POST['path'] ) ) : '';
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- the nonce is verified on the next line.
+	$req_path    = isset( $_POST['path'] ) ? wpsc_sanitize_cache_path( wp_unslash( $_POST['path'] ) ) : '';
 	$valid_nonce = ( $req_path && isset( $_POST['nonce'] ) ) ? wp_verify_nonce( $_POST['nonce'], 'delete-cache-' . $_POST['path'] . '_' . $_POST['admin'] ) : false;
 
 	if ( ! $valid_nonce ) {
@@ -155,7 +157,9 @@ function wpsc_delete_cache_directory() {
 		return false;
 	}
 
-	$path = realpath( trailingslashit( get_supercache_dir() . str_replace( '..', '', preg_replace( '/:.*$/', '', $req_path ) ) ) );
+	// $req_path comes from the browser's REQUEST_URI, so its case is whatever the
+	// visitor's browser sent. Normalise it to the spelling on disk. See #1081.
+	$path = realpath( trailingslashit( get_supercache_dir() . wpsc_normalize_uri_case( str_replace( '..', '', preg_replace( '/:.*$/', '', $req_path ) ) ) ) );
 
 	if ( $path ) {
 		if ( isset( $_POST['admin'] ) && (int) $_POST['admin'] === 1 ) {

--- a/inc/htaccess.php
+++ b/inc/htaccess.php
@@ -154,7 +154,9 @@ function wpsc_get_htaccess_info() {
 	}
 
 	$home_path = trailingslashit( $home_path );
-	$home_root_lc = str_replace( '//', '/', strtolower( $home_root ) );
+	// The rewrite rules point at supercache directories, so the home root has to
+	// be spelled the way those directories are. See #1081.
+	$home_root_lc = str_replace( '//', '/', wpsc_normalize_uri_case( $home_root ) );
 	$inst_root = str_replace( '//', '/', '/' . trailingslashit( str_replace( $content_dir_root, '', str_replace( '\\', '/', WP_CONTENT_DIR ) ) ) );
 	$wprules = implode( "\n", extract_from_markers( $home_path.'.htaccess', 'WordPress' ) );
 	$wprules = str_replace( "RewriteEngine On\n", '', $wprules );

--- a/inc/preload.php
+++ b/inc/preload.php
@@ -226,7 +226,11 @@ function wp_cron_preload_cache() {
 					}
 
 					$url_info = wp_parse_url( $url );
-					$dir      = get_supercache_dir() . $url_info['path'];
+					// get_term_link() spells percent escapes in lowercase; the
+					// directory on disk has them uppercased. Without this the
+					// delete misses and the wp_remote_get() below is served the
+					// stale file it was meant to replace. See #1081.
+					$dir = get_supercache_dir() . wpsc_normalize_uri_case( $url_info['path'] );
 					wp_cache_debug( "wp_cron_preload_cache: delete $dir" );
 					wpsc_delete_files( $dir );
 					prune_super_cache( trailingslashit( $dir ) . 'feed/', true );

--- a/inc/preload.php
+++ b/inc/preload.php
@@ -225,12 +225,11 @@ function wp_cron_preload_cache() {
 						continue;
 					}
 
-					$url_info = wp_parse_url( $url );
 					// get_term_link() spells percent escapes in lowercase; the
 					// directory on disk has them uppercased. Without this the
 					// delete misses and the wp_remote_get() below is served the
 					// stale file it was meant to replace. See #1081.
-					$dir = get_supercache_dir() . wpsc_normalize_uri_case( $url_info['path'] );
+					$dir = wpsc_supercache_dir_for_url( $url );
 					wp_cache_debug( "wp_cron_preload_cache: delete $dir" );
 					wpsc_delete_files( $dir );
 					prune_super_cache( trailingslashit( $dir ) . 'feed/', true );

--- a/inc/settings-forms.php
+++ b/inc/settings-forms.php
@@ -63,7 +63,10 @@ function wpsc_update_direct_pages() {
 			$out .= "'$page', ";
 
 			@unlink( trailingslashit( ABSPATH . $page ) . "index.html" );
-			wpsc_delete_files( get_supercache_dir() . $page );
+			// $page is typed by an admin, so its case is whatever they typed, while
+			// the supercache directory for it is lowercased. The unlink above is a
+			// real file under ABSPATH and must keep the spelling as given. See #1081.
+			wpsc_delete_files( get_supercache_dir() . wpsc_normalize_uri_case( $page ) );
 		}
 	}
 

--- a/plugins/domain-mapping.php
+++ b/plugins/domain-mapping.php
@@ -12,7 +12,12 @@ function domain_mapping_gc_cache( $function, $directory ) {
 		return;
 	}
 
-	$sitedir = trailingslashit( preg_replace( '`^(https?:)?//`', '', $siteurl ) );
+	// Lowercased to match the directory the serving side writes.
+	// get_current_url_supercache_dir() builds the host segment from
+	// $WPSC_HTTP_HOST, which wp-cache-base.php has already lowercased, so a mapped
+	// domain carrying any uppercase was looked for in a directory that was never
+	// written. See #1081.
+	$sitedir = trailingslashit( strtolower( preg_replace( '`^(https?:)?//`', '', $siteurl ) ) );
 
 	if ( 'homepage' === $directory ) {
 		$directory = '';
@@ -40,7 +45,12 @@ function domain_mapping_supercachedir( $dir ) {
 		return $dir;
 	}
 
-	$sitedir = trailingslashit( preg_replace( '`^(https?:)?//`', '', $siteurl ) );
+	// Lowercased to match the directory the serving side writes.
+	// get_current_url_supercache_dir() builds the host segment from
+	// $WPSC_HTTP_HOST, which wp-cache-base.php has already lowercased, so a mapped
+	// domain carrying any uppercase was looked for in a directory that was never
+	// written. See #1081.
+	$sitedir = trailingslashit( strtolower( preg_replace( '`^(https?:)?//`', '', $siteurl ) ) );
 
 	return trailingslashit( $cache_path . 'supercache/' . $sitedir );
 }

--- a/rest/class.wp-super-cache-rest-delete-cache.php
+++ b/rest/class.wp-super-cache-rest-delete-cache.php
@@ -21,7 +21,9 @@ class WP_Super_Cache_Rest_Delete_Cache extends WP_REST_Controller {
 		} elseif ( isset( $params['url'] ) ) {
 			global $cache_path;
 
-			$directory = $cache_path . 'supercache/' . $params[ 'url' ];
+			// The caller sends whatever spelling it has, but the directory on disk
+			// is lowercase with the percent escapes uppercased. See #1081.
+			$directory = $cache_path . 'supercache/' . wpsc_normalize_uri_case( $params['url'] );
 			wpsc_delete_files( $directory );
 			prune_super_cache( $directory . '/page', true );
 

--- a/rest/class.wp-super-cache-rest-delete-cache.php
+++ b/rest/class.wp-super-cache-rest-delete-cache.php
@@ -21,9 +21,18 @@ class WP_Super_Cache_Rest_Delete_Cache extends WP_REST_Controller {
 		} elseif ( isset( $params['url'] ) ) {
 			global $cache_path;
 
+			// This is the one caller that hands the helpers raw JSON, so the value is
+			// checked here rather than trusted. An empty result would build the site's
+			// supercache root, which wpsc_delete_files() protects, but it is clearer to
+			// refuse than to rely on that.
+			$url = wpsc_sanitize_cache_path( $params['url'] );
+			if ( '' === $url ) {
+				return new WP_Error( 'invalid_url', __( 'Not a path this cache can delete.', 'wp-super-cache' ), array( 'status' => 400 ) );
+			}
+
 			// The caller sends whatever spelling it has, but the directory on disk
 			// is lowercase with the percent escapes uppercased. See #1081.
-			$directory = $cache_path . 'supercache/' . wpsc_normalize_uri_case( $params['url'] );
+			$directory = $cache_path . 'supercache/' . wpsc_normalize_uri_case( $url );
 			wpsc_delete_files( $directory );
 			prune_super_cache( $directory . '/page', true );
 

--- a/tests/php/integration/DeleteUrlCacheCaseTest.php
+++ b/tests/php/integration/DeleteUrlCacheCaseTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Case-normalisation tests for the cache deletion paths.
+ *
+ * #1080 fixed the post's own directory. This covers the archives it appears on:
+ * a category, tag or author with a non-ASCII slug. WordPress stores those slugs
+ * with LOWERCASE percent escapes, so get_term_link() and get_author_posts_url()
+ * hand us a URL that does not match the directory on disk, which has them
+ * UPPERCASE. Without normalisation nothing is deleted and the archive keeps
+ * serving a stale page after an edit. See #1081.
+ *
+ * The rule itself is covered in the smoke tier by WpscNormalizeUriCaseTest,
+ * which runs in CI. These tests answer a different question: do the deletion
+ * call sites actually apply it. So they build their fixture directories with
+ * wpsc_normalize_uri_case() and assert separately that the raw URL and the
+ * normalised path really do differ, which is what makes the assertion mean
+ * something.
+ *
+ * Integration tier: needs terms, users, permalinks and a real filesystem.
+ *
+ * @package automattic/wp-super-cache
+ */
+class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
+
+	/**
+	 * Kazakh name from the original bug report. sanitize_title() turns it into a
+	 * slug full of lowercase percent escapes.
+	 */
+	const NON_ASCII_NAME = 'Ұlytau oblysy';
+
+	/** @var string Cache directory this class works in, established once. */
+	private static $cache_path;
+
+	/** @var bool Whether setUpBeforeClass() created self::$cache_path itself. */
+	private static $created_cache_path = false;
+
+	/**
+	 * Globals this class overwrites, snapshotted per test and put back afterwards.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $saved_globals = array();
+
+	/**
+	 * Establish a cache directory that the deletion functions will accept.
+	 *
+	 * The function wpsc_is_in_cache_directory() resolves $cache_path once and keeps it in a
+	 * static with no way to reset it, so whichever test class calls it first
+	 * decides what counts as "inside the cache directory" for the rest of the
+	 * process. Rather than guard against that and fail, work inside whatever path
+	 * has already been established, and only pick our own when the static is
+	 * still empty.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		$statics  = ( new ReflectionFunction( 'wpsc_is_in_cache_directory' ) )->getStaticVariables();
+		$memoised = isset( $statics['rp_cache_path'] ) ? $statics['rp_cache_path'] : '';
+
+		self::$cache_path = ( is_string( $memoised ) && '' !== $memoised )
+			? trailingslashit( $memoised )
+			: sys_get_temp_dir() . '/wpsc-delete-url-cache-test/';
+
+		if ( ! is_dir( self::$cache_path ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- temp dir for a test fixture.
+			mkdir( self::$cache_path, 0777, true );
+			self::$created_cache_path = true;
+		}
+	}
+
+	public static function tear_down_after_class() {
+		if ( self::$created_cache_path && is_dir( self::$cache_path ) ) {
+			self::rmdir_recursive( self::$cache_path );
+		}
+
+		parent::tear_down_after_class();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		$overrides = array(
+			'cache_path'          => self::$cache_path,
+			'file_prefix'         => 'wp-cache-',
+			// Rebuild rather than delete, so the assertion does not depend on the
+			// fixture file being more than ten seconds old.
+			'cache_rebuild_files' => 1,
+		);
+
+		$this->saved_globals = array();
+		foreach ( $overrides as $key => $value ) {
+			$this->saved_globals[ $key ] = array_key_exists( $key, $GLOBALS ) ? $GLOBALS[ $key ] : null;
+			$GLOBALS[ $key ]             = $value;
+		}
+
+		$this->set_permalink_structure( '/%postname%/' );
+
+		// WP_Rewrite::init() clears extra_permastructs, and the taxonomy ones are
+		// only put back by create_initial_taxonomies(). Without this get_term_link()
+		// returns ?cat=N and the tests below have no percent escapes to work with.
+		create_initial_taxonomies();
+	}
+
+	public function tear_down() {
+		foreach ( $this->saved_globals as $key => $value ) {
+			if ( null === $value ) {
+				unset( $GLOBALS[ $key ] );
+			} else {
+				$GLOBALS[ $key ] = $value;
+			}
+		}
+		$this->saved_globals = array();
+
+		$supercache_dir = self::$cache_path . 'supercache';
+		if ( is_dir( $supercache_dir ) ) {
+			self::rmdir_recursive( $supercache_dir );
+		}
+
+		$this->set_permalink_structure( '' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove a directory and everything under it.
+	 *
+	 * @param string $dir Directory to remove.
+	 */
+	private static function rmdir_recursive( $dir ) {
+		// phpcs:disable WordPress.WP.AlternativeFunctions -- test fixture cleanup.
+		foreach ( (array) glob( trailingslashit( $dir ) . '*' ) as $entry ) {
+			if ( is_dir( $entry ) ) {
+				self::rmdir_recursive( $entry );
+			} else {
+				unlink( $entry );
+			}
+		}
+		rmdir( $dir );
+		// phpcs:enable WordPress.WP.AlternativeFunctions
+	}
+
+	/**
+	 * Write a cached index.html for a URL, in the directory the serving side would
+	 * have created for it, and assert the fixture is worth having.
+	 *
+	 * @param string $url Absolute URL of the page being cached.
+	 * @return string Path of the cached file.
+	 */
+	private function cache_page( $url ) {
+		$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+
+		$this->assertMatchesRegularExpression(
+			'/%[0-9a-f]{2}/',
+			$path,
+			"Expected lowercase percent escapes in {$url}; without them this test proves nothing."
+		);
+
+		$normalised = wpsc_normalize_uri_case( $path );
+		$this->assertNotSame(
+			$path,
+			$normalised,
+			'The URL and the directory on disk have to be spelled differently, or the bug cannot reproduce.'
+		);
+
+		$dir = trailingslashit( untrailingslashit( get_supercache_dir() ) . $normalised );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $dir, 0777, true );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_put_contents -- test fixture.
+		file_put_contents( $dir . 'index.html', '<html>cached</html>' );
+
+		return $dir . 'index.html';
+	}
+
+	/**
+	 * Assert a cached file was cleared. With $cache_rebuild_files on, "cleared"
+	 * means renamed to .needs-rebuild rather than unlinked.
+	 *
+	 * @param string $file Path returned by cache_page().
+	 */
+	private function assertCacheCleared( $file ) {
+		$this->assertFileDoesNotExist( $file, 'Cached file was left in place.' );
+		$this->assertFileExists( $file . '.needs-rebuild' );
+	}
+
+	/**
+	 * Saving a post clears the category archive it appears on, even when the
+	 * category slug is percent-encoded. This is the reported bug.
+	 */
+	public function test_category_archive_with_non_ascii_slug_is_cleared() {
+		$term_id  = self::factory()->category->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'category' );
+		$this->assertIsString( $term_url );
+
+		$cached  = $this->cache_page( $term_url );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_category' => array( $term_id ),
+			)
+		);
+
+		wpsc_delete_post_archives( $post_id );
+
+		$this->assertCacheCleared( $cached );
+	}
+
+	/** The same for a tag, which reaches the deletion path through a different taxonomy. */
+	public function test_tag_archive_with_non_ascii_slug_is_cleared() {
+		$term_id  = self::factory()->tag->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'post_tag' );
+		$this->assertIsString( $term_url );
+
+		$cached  = $this->cache_page( $term_url );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		wp_set_post_tags( $post_id, array( $term_id ) );
+
+		wpsc_delete_post_archives( $post_id );
+
+		$this->assertCacheCleared( $cached );
+	}
+
+	/**
+	 * The REST delete-cache endpoint goes through wpsc_delete_post_cache(), which
+	 * hands the post's own permalink to wpsc_delete_url_cache().
+	 *
+	 * The author archive is not covered here. get_author_posts_url() builds its
+	 * URL from user_nicename, and WordPress runs that through
+	 * sanitize_user( $nicename, true ), which strips percent escapes, so a
+	 * nicename cannot carry them in the first place. Reproducing it would mean
+	 * writing the row by hand, which would test a state WordPress does not
+	 * produce. The shared helper covers the path regardless.
+	 */
+	public function test_post_cache_deletion_handles_a_non_ascii_permalink() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => self::NON_ASCII_NAME,
+				'post_status' => 'publish',
+			)
+		);
+
+		$cached = $this->cache_page( get_permalink( $post_id ) );
+
+		$this->assertTrue( wpsc_delete_post_cache( $post_id ) );
+
+		$this->assertCacheCleared( $cached );
+	}
+
+	/**
+	 * The deprecated wpsc_delete_cats_tags() builds its paths from the term slug
+	 * by hand rather than going through wpsc_delete_url_cache(), so it needs the
+	 * normalisation of its own. It is still callable, so it is still tested.
+	 */
+	public function test_deprecated_cats_tags_deletion_handles_non_ascii_slug() {
+		$term_id  = self::factory()->category->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'category' );
+		$this->assertIsString( $term_url );
+
+		$cached  = $this->cache_page( $term_url );
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_category' => array( $term_id ),
+			)
+		);
+
+		$this->setExpectedDeprecated( 'wpsc_delete_cats_tags' );
+		wpsc_delete_cats_tags( $post_id );
+
+		// This path prunes rather than rebuilds, so the file is removed outright.
+		$this->assertFileDoesNotExist( $cached );
+	}
+
+	/**
+	 * The admin bar / REST "delete cache" button takes its path from the browser's
+	 * REQUEST_URI, whose case the browser controls.
+	 */
+	public function test_delete_cache_directory_normalises_the_posted_path() {
+		$term_id  = self::factory()->category->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'category' );
+		$this->assertIsString( $term_url );
+
+		$cached = $this->cache_page( $term_url );
+		$path   = (string) wp_parse_url( $term_url, PHP_URL_PATH );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$_POST['path']  = $path;
+		$_POST['admin'] = 0;
+		$_POST['nonce'] = wp_create_nonce( 'delete-cache-' . $path . '_0' );
+
+		wpsc_delete_cache_directory();
+
+		unset( $_POST['path'], $_POST['admin'], $_POST['nonce'] );
+
+		$this->assertFileDoesNotExist( $cached );
+	}
+}

--- a/tests/php/integration/DeleteUrlCacheCaseTest.php
+++ b/tests/php/integration/DeleteUrlCacheCaseTest.php
@@ -42,6 +42,13 @@ class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
 	private $saved_globals = array();
 
 	/**
+	 * Fixture directories created by cache_page(), removed in tear_down().
+	 *
+	 * @var string[]
+	 */
+	private $created_dirs = array();
+
+	/**
 	 * Establish a cache directory that the deletion functions will accept.
 	 *
 	 * The function wpsc_is_in_cache_directory() resolves $cache_path once and keeps it in a
@@ -111,10 +118,16 @@ class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
 		}
 		$this->saved_globals = array();
 
-		$supercache_dir = self::$cache_path . 'supercache';
-		if ( is_dir( $supercache_dir ) ) {
-			self::rmdir_recursive( $supercache_dir );
+		// Only what this class made. set_up_before_class() may have adopted a
+		// cache_path it did not create, and in a wp-env run that is the site's real
+		// wp-content/cache, so removing 'supercache' wholesale would take the
+		// installation's cache with it.
+		foreach ( array_reverse( $this->created_dirs ) as $dir ) {
+			if ( is_dir( $dir ) ) {
+				self::rmdir_recursive( $dir );
+			}
 		}
+		$this->created_dirs = array();
 
 		$this->set_permalink_structure( '' );
 		parent::tear_down();
@@ -165,6 +178,7 @@ class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
 		mkdir( $dir, 0777, true );
+		$this->created_dirs[] = $dir;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_put_contents -- test fixture.
 		file_put_contents( $dir . 'index.html', '<html>cached</html>' );
 
@@ -268,6 +282,123 @@ class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
 
 		// This path prunes rather than rebuilds, so the file is removed outright.
 		$this->assertFileDoesNotExist( $cached );
+	}
+
+	/**
+	 * The seam wp_cron_preload_cache() uses to pick the directory it deletes.
+	 *
+	 * That caller deletes and then immediately refetches, so a delete that misses
+	 * is served the stale file it was meant to replace, which is why it matters
+	 * most and why the computation was pulled out where a test can reach it.
+	 */
+	public function test_supercache_dir_for_url_normalises_a_term_link() {
+		$term_id  = self::factory()->category->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'category' );
+		$this->assertIsString( $term_url );
+
+		$path = (string) wp_parse_url( $term_url, PHP_URL_PATH );
+		$this->assertMatchesRegularExpression( '/%[0-9a-f]{2}/', $path, 'Fixture has no lowercase escapes to normalise.' );
+
+		$dir = wpsc_supercache_dir_for_url( $term_url );
+
+		// get_supercache_dir() is already trailingslashed and the path opens with a
+		// slash, so the result carries a doubled one. That is what the inline
+		// version produced too, and realpath() collapses it.
+		$this->assertSame( get_supercache_dir() . wpsc_normalize_uri_case( $path ), $dir );
+		$this->assertNotSame(
+			get_supercache_dir() . $path,
+			$dir,
+			'The raw and normalised directories have to differ, or this proves nothing.'
+		);
+	}
+
+	/**
+	 * A URL with no path at all. wp_parse_url() omits the key entirely, which the
+	 * inline version this replaced dereferenced anyway.
+	 */
+	public function test_supercache_dir_for_url_handles_a_url_with_no_path() {
+		$this->assertSame(
+			get_supercache_dir() . '/',
+			wpsc_supercache_dir_for_url( 'https://example.com' )
+		);
+	}
+
+	/**
+	 * A URL with a query string is a no-op, not a nonce failure.
+	 *
+	 * The admin bar renders the delete button on any URL, so on a site using plain
+	 * permalinks every path is '/?p=123' and on a search page it is '/?s=foo'.
+	 * Those have never had a supercache directory and the delete has always done
+	 * nothing, quietly. What must not happen is the path being emptied before the
+	 * nonce check, because then wpsc_admin_bar_delete_cache() dies with "Problem
+	 * with nonce" on a request whose nonce was perfectly good.
+	 */
+	public function test_query_string_path_is_a_no_op_rather_than_a_nonce_failure() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		foreach ( array( '/?p=123', '/?s=foo' ) as $path ) {
+			$_POST['path']  = $path;
+			$_POST['admin'] = 0;
+			$_POST['nonce'] = wp_create_nonce( 'delete-cache-' . $path . '_0' );
+
+			$result = wpsc_delete_cache_directory();
+
+			unset( $_POST['path'], $_POST['admin'], $_POST['nonce'] );
+
+			$this->assertNotFalse(
+				$result,
+				"Path {$path} was rejected before the nonce check, so the caller would report a nonce failure that did not happen."
+			);
+		}
+	}
+
+	/**
+	 * The REST endpoint's 'url' branch, which is the one caller that hands the
+	 * helpers a value straight out of JSON.
+	 *
+	 * Note the path it wants is host-prefixed: it builds from $cache_path
+	 * . 'supercache/' rather than get_supercache_dir(), so the host segment has to
+	 * come from the caller.
+	 */
+	public function test_rest_url_deletion_normalises_the_posted_url() {
+		require_once __DIR__ . '/../../../rest/class.wp-super-cache-rest-delete-cache.php';
+
+		$term_id  = self::factory()->category->create( array( 'name' => self::NON_ASCII_NAME ) );
+		$term_url = get_term_link( $term_id, 'category' );
+		$this->assertIsString( $term_url );
+
+		$cached = $this->cache_page( $term_url );
+		$host   = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$path   = (string) wp_parse_url( $term_url, PHP_URL_PATH );
+
+		$request = new WP_REST_Request( 'POST', '/wp-super-cache/v1/cache' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'url' => $host . $path ) ) );
+
+		$controller = new WP_Super_Cache_Rest_Delete_Cache();
+		$response   = $controller->callback( $request );
+
+		$this->assertNotWPError( $response );
+		$this->assertFileDoesNotExist( $cached );
+	}
+
+	/**
+	 * A 'url' that is not a path is refused rather than being cleaned up into one.
+	 * Without the check it would build the site's supercache root, which
+	 * wpsc_delete_files() protects, but refusing says so out loud.
+	 */
+	public function test_rest_url_deletion_refuses_a_url_it_cannot_use() {
+		require_once __DIR__ . '/../../../rest/class.wp-super-cache-rest-delete-cache.php';
+
+		$controller = new WP_Super_Cache_Rest_Delete_Cache();
+
+		foreach ( array( '/blog/<script>/', array( 'x' ), "/blog/x\n" ) as $bad_url ) {
+			$request = new WP_REST_Request( 'POST', '/wp-super-cache/v1/cache' );
+			$request->set_header( 'Content-Type', 'application/json' );
+			$request->set_body( wp_json_encode( array( 'url' => $bad_url ) ) );
+
+			$this->assertWPError( $controller->callback( $request ) );
+		}
 	}
 
 	/**

--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -150,6 +150,41 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The host segment is lowercased when it comes from the home option.
+	 *
+	 * $WPSC_HTTP_HOST is empty under WP-CLI and cron, and the fallback reads the
+	 * host out of the home option. wp-cache-base.php lowercases the HTTP_HOST it
+	 * normally uses, so an install whose home option carries uppercase had those
+	 * requests name a different directory than its web requests did.
+	 *
+	 * Nothing here memoises: a home option that site_url() does not appear in
+	 * sends the function down its DONOTREMEMBER branch, so key 0 stays free for
+	 * the test above.
+	 */
+	public function test_host_from_the_home_option_is_lowercased() {
+		$GLOBALS['WPSC_HTTP_HOST'] = '';
+
+		// Filtered rather than saved with update_option(): WP_HOME is defined in the
+		// test config, and core's _config_wp_home() puts that back on option_home at
+		// priority 10, so a stored value never survives to be read.
+		$uppercase_home = static function () {
+			return 'https://Example.ORG';
+		};
+		add_filter( 'option_home', $uppercase_home, 20 );
+
+		try {
+			list( $post_id ) = $this->publish( 'Hello There' );
+
+			$dir = get_current_url_supercache_dir( $post_id );
+		} finally {
+			remove_filter( 'option_home', $uppercase_home, 20 );
+		}
+
+		$this->assertStringContainsString( 'supercache/example.org/', $dir );
+		$this->assertStringNotContainsString( 'Example.ORG', $dir );
+	}
+
+	/**
 	 * The rest of the path is lowercased on the post ID branch too. An install in
 	 * a subdirectory with a capital in it used to produce /Blog/... here while the
 	 * directory on disk was /blog/..., because inc/htaccess.php lowercases the

--- a/tests/php/smoke/WpscNormalizeUriCaseTest.php
+++ b/tests/php/smoke/WpscNormalizeUriCaseTest.php
@@ -88,12 +88,41 @@ class WpscNormalizeUriCaseTest extends TestCase {
 	}
 
 	/**
-	 * Raw UTF-8 bytes survive. strtolower() is byte-wise ASCII, so the high bytes
-	 * of an unencoded unicode path pass through unchanged rather than being
-	 * mangled.
+	 * Raw UTF-8 bytes survive. Only [A-Z] is lowercased, so the high bytes of an
+	 * unencoded unicode path are never in range. Doing this with strtolower() on
+	 * the whole string would hold on PHP 8.2+, where it is locale-independent, but
+	 * not on 7.4-8.1, which this plugin still supports.
 	 */
 	public function test_raw_utf8_is_not_mangled(): void {
 		$this->assertSame( '/Ұlytau/', wpsc_normalize_uri_case( '/Ұlytau/' ) );
+	}
+
+	/**
+	 * The uppercase Cyrillic above is 0xD2 0xB1, inside the 0xC0-0xDE range a
+	 * single-byte locale would have lowercased. Pinned under such a locale so the
+	 * claim above is tested rather than asserted. setlocale() is a no-op if the
+	 * locale is missing, in which case this just repeats the test above.
+	 */
+	public function test_raw_utf8_is_not_mangled_under_a_single_byte_locale(): void {
+		$previous = setlocale( LC_CTYPE, '0' );
+		setlocale( LC_CTYPE, 'de_DE.ISO-8859-1', 'de_DE', 'en_US.ISO-8859-1' );
+
+		try {
+			$this->assertSame( '/Ұlytau/', wpsc_normalize_uri_case( '/Ұlytau/' ) );
+		} finally {
+			setlocale( LC_CTYPE, $previous );
+		}
+	}
+
+	/**
+	 * Not a string means '' rather than a cast. The REST delete-cache endpoint
+	 * feeds this straight from get_json_params(), where 'url' can be an array, and
+	 * (string) would have made that the directory name "Array". See #1081.
+	 */
+	public function test_non_string_input_is_rejected(): void {
+		$this->assertSame( '', wpsc_normalize_uri_case( array( 'x' ) ) );
+		$this->assertSame( '', wpsc_normalize_uri_case( null ) );
+		$this->assertSame( '', wpsc_normalize_uri_case( false ) );
 	}
 
 	/** An empty string is not a special case. */

--- a/tests/php/smoke/WpscNormalizeUriCaseTest.php
+++ b/tests/php/smoke/WpscNormalizeUriCaseTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Smoke tests for wpsc_normalize_uri_case().
+ *
+ * Supercache directory names are lowercase with any percent escapes uppercased.
+ * The same path reaches us spelled two ways: sanitize_title_with_dashes() stores
+ * lowercase escapes in post_name (utf8_uri_encode() builds them with dechex()),
+ * while a URL encoder emits them uppercase. We normalise both to one spelling so
+ * they land on one directory. Uppercase is the target because RFC 3986 section
+ * 2.1 recommends it and because it is the shape already on disk.
+ *
+ * The helper is pure, so it belongs in the smoke tier. That matters: CI runs
+ * `composer test-php`, which is smoke only, so this is the tier where the rule is
+ * actually covered on every push. See #1081.
+ *
+ * @package automattic/wp-super-cache
+ */
+
+// wp-cache-phase2.php is loaded by the smoke bootstrap (tests/php/bootstrap-smoke.php).
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ::wpsc_normalize_uri_case
+ */
+class WpscNormalizeUriCaseTest extends TestCase {
+
+	/**
+	 * Both spellings of the Kazakh slug from #1080, plus the shape we expect on
+	 * disk. The lowercase form is what WordPress stores in post_name; the
+	 * uppercase form is what a URL encoder produces for the same characters.
+	 */
+	const SLUG_LOWER = '/%d2%b1lytau-oblysy/';
+	const SLUG_UPPER = '/%D2%B1LYTAU-OBLYSY/';
+	const SLUG_DISK  = '/%D2%B1lytau-oblysy/';
+
+	/** WordPress's own spelling normalises to the directory on disk. */
+	public function test_lowercase_escapes_are_uppercased(): void {
+		$this->assertSame( self::SLUG_DISK, wpsc_normalize_uri_case( self::SLUG_LOWER ) );
+	}
+
+	/** A URL encoder's spelling of the same path normalises to the same place. */
+	public function test_uppercase_input_normalises_to_the_same_result(): void {
+		$this->assertSame( self::SLUG_DISK, wpsc_normalize_uri_case( self::SLUG_UPPER ) );
+	}
+
+	/**
+	 * The regression from #1080 and #1081, stated directly: the two spellings a
+	 * visitor and WordPress produce for one URL have to collapse to one string.
+	 */
+	public function test_both_spellings_agree(): void {
+		$this->assertSame(
+			wpsc_normalize_uri_case( self::SLUG_LOWER ),
+			wpsc_normalize_uri_case( self::SLUG_UPPER )
+		);
+	}
+
+	/** Mixed case in a single escape is normalised too. */
+	public function test_mixed_case_escapes_are_uppercased(): void {
+		$this->assertSame( '/%D2%B1/', wpsc_normalize_uri_case( '/%d2%B1/' ) );
+	}
+
+	/**
+	 * Order matters. Lowercasing has to happen first, otherwise the ASCII around
+	 * an escape would drag the escape back down with it.
+	 */
+	public function test_ascii_is_lowercased_around_the_escapes(): void {
+		$this->assertSame( '/blog/%D2%B1lytau/', wpsc_normalize_uri_case( '/Blog/%D2%B1LYTAU/' ) );
+	}
+
+	/** A plain ASCII path is just lowercased. */
+	public function test_path_without_escapes_is_lowercased(): void {
+		$this->assertSame( '/blog/hello-there/', wpsc_normalize_uri_case( '/Blog/Hello-There/' ) );
+	}
+
+	/** A path that is already normalised comes back untouched. */
+	public function test_normalising_twice_changes_nothing(): void {
+		$this->assertSame( self::SLUG_DISK, wpsc_normalize_uri_case( self::SLUG_DISK ) );
+	}
+
+	/**
+	 * A percent that is not the start of an escape is left alone. `%zz` is not
+	 * hex, and a bare `%` has nothing following it.
+	 */
+	public function test_percent_that_is_not_an_escape_is_left_alone(): void {
+		$this->assertSame( '/50%-off/', wpsc_normalize_uri_case( '/50%-Off/' ) );
+		$this->assertSame( '/%zz/', wpsc_normalize_uri_case( '/%ZZ/' ) );
+	}
+
+	/**
+	 * Raw UTF-8 bytes survive. strtolower() is byte-wise ASCII, so the high bytes
+	 * of an unencoded unicode path pass through unchanged rather than being
+	 * mangled.
+	 */
+	public function test_raw_utf8_is_not_mangled(): void {
+		$this->assertSame( '/Ұlytau/', wpsc_normalize_uri_case( '/Ұlytau/' ) );
+	}
+
+	/** An empty string is not a special case. */
+	public function test_empty_string(): void {
+		$this->assertSame( '', wpsc_normalize_uri_case( '' ) );
+	}
+}

--- a/tests/php/smoke/WpscSanitizeCachePathTest.php
+++ b/tests/php/smoke/WpscSanitizeCachePathTest.php
@@ -99,17 +99,6 @@ class WpscSanitizeCachePathTest extends TestCase {
 	}
 
 	/**
-	 * A query string is rejected rather than having its punctuation removed.
-	 * Dropping the '?s=foo' off a search page would leave '/', and the site root
-	 * is a real directory, so the delete would move to a page nobody asked to
-	 * clear.
-	 */
-	public function test_query_string_is_rejected(): void {
-		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/x/?id=something' ) );
-		$this->assertSame( '', wpsc_sanitize_cache_path( '/?s=foo' ) );
-	}
-
-	/**
 	 * The anchor is \z, not $, so a trailing newline cannot ride along on an
 	 * otherwise valid path.
 	 */
@@ -125,6 +114,37 @@ class WpscSanitizeCachePathTest extends TestCase {
 	public function test_non_string_input_is_rejected(): void {
 		$this->assertSame( '', wpsc_sanitize_cache_path( array( '/blog/' ) ) );
 		$this->assertSame( '', wpsc_sanitize_cache_path( null ) );
+	}
+
+	/**
+	 * A query string is kept whole rather than rejected or trimmed.
+	 *
+	 * The admin bar puts the delete button on any URL, so on a site using plain
+	 * permalinks every path is '/?p=123' and on a search page it is '/?s=foo'.
+	 * Rejecting those would empty $req_path and send wpsc_delete_cache_directory()
+	 * down the branch that reports a nonce failure that did not happen. Trimming
+	 * them would leave '/', the site root, which is a real directory and not the
+	 * one the nonce covered. Keeping them means the path simply does not resolve,
+	 * because supercache never names a directory after a query string, and the
+	 * delete is the no-op it has always been.
+	 */
+	public function test_query_string_is_kept_whole(): void {
+		$this->assertSame( '/?p=123', wpsc_sanitize_cache_path( '/?p=123' ) );
+		$this->assertSame( '/?s=foo', wpsc_sanitize_cache_path( '/?s=foo' ) );
+		$this->assertSame( '/blog/x/?utm_source=y', wpsc_sanitize_cache_path( '/blog/x/?utm_source=y' ) );
+	}
+
+	/**
+	 * Encoded traversal passes the allow-list, deliberately.
+	 *
+	 * '%2e%2e%2f' is only percent escapes, which the whole point of this function
+	 * is to preserve. It is safe because nothing downstream decodes it: realpath()
+	 * looks for a directory literally named '%2E%2E%2F' and does not find one. The
+	 * assertion is here so that if anything ever does decode it, this stops being
+	 * a passing test.
+	 */
+	public function test_encoded_traversal_is_passed_through_undecoded(): void {
+		$this->assertSame( '/%2e%2e%2f', wpsc_sanitize_cache_path( '/%2e%2e%2f' ) );
 	}
 
 	/** An empty string is not a special case. */

--- a/tests/php/smoke/WpscSanitizeCachePathTest.php
+++ b/tests/php/smoke/WpscSanitizeCachePathTest.php
@@ -68,10 +68,16 @@ class WpscSanitizeCachePathTest extends TestCase {
 	}
 
 	/**
-	 * A colon is kept here and truncated later by the caller, which is where that
-	 * rule has always lived. This pins the division of labour.
+	 * Colons go. wpsc_delete_cache_directory() truncates at ':' after calling
+	 * this, so that line now has nothing left to find, but it is kept as a guard
+	 * against this allow-list changing. Pinned here so the two stay in step.
 	 */
-	public function test_query_and_colon_handling(): void {
+	public function test_colons_are_dropped(): void {
+		$this->assertSame( '/blog/x/8080/evil', wpsc_sanitize_cache_path( '/blog/x/:8080/evil' ) );
+	}
+
+	/** A query string loses the characters that make it one. */
+	public function test_query_string_punctuation_is_dropped(): void {
 		$this->assertSame( '/blog/x/idsomething', wpsc_sanitize_cache_path( '/blog/x/?id=something' ) );
 	}
 

--- a/tests/php/smoke/WpscSanitizeCachePathTest.php
+++ b/tests/php/smoke/WpscSanitizeCachePathTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Smoke tests for wpsc_sanitize_cache_path().
+ *
+ * This replaced a sanitize_text_field() call in the delete-cache button. That
+ * function strips every percent escape it sees, so the button could never delete
+ * a supercache directory for a non-ASCII slug: /category/%d2%b1lytau/ arrived as
+ * /category/lytau/ and realpath() found nothing. See #1081.
+ *
+ * The value is used to build a filesystem path, so the tests below cover both
+ * halves of the job: keep what a URL path legitimately contains, drop everything
+ * else.
+ *
+ * @package automattic/wp-super-cache
+ */
+
+// wp-cache-phase2.php is loaded by the smoke bootstrap (tests/php/bootstrap-smoke.php).
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ::wpsc_sanitize_cache_path
+ */
+class WpscSanitizeCachePathTest extends TestCase {
+
+	/** The regression: percent escapes survive, which sanitize_text_field() did not allow. */
+	public function test_percent_escapes_are_kept(): void {
+		$this->assertSame(
+			'/category/%d2%b1lytau-oblysy/',
+			wpsc_sanitize_cache_path( '/category/%d2%b1lytau-oblysy/' )
+		);
+	}
+
+	/** An ordinary path is returned unchanged. */
+	public function test_plain_path_is_unchanged(): void {
+		$this->assertSame( '/blog/hello-there/', wpsc_sanitize_cache_path( '/blog/hello-there/' ) );
+	}
+
+	/** The remaining characters a URL path can carry are all kept. */
+	public function test_other_path_characters_are_kept(): void {
+		$this->assertSame( '/a_b/c.d/~e-f/2026/', wpsc_sanitize_cache_path( '/a_b/c.d/~e-f/2026/' ) );
+	}
+
+	/**
+	 * Angle brackets, quotes and whitespace are dropped. The old
+	 * preg_replace() in wpsc_admin_bar_render() removed exactly these before the
+	 * value ever reached a nonce, and the allow-list keeps that guarantee.
+	 */
+	public function test_markup_and_whitespace_are_dropped(): void {
+		$this->assertSame( '/blog/scriptalert1/script/', wpsc_sanitize_cache_path( "/blog/<script>alert(1)</script>/\r\n" ) );
+		$this->assertSame( '/blog/one/', wpsc_sanitize_cache_path( '/blog/ one /' ) );
+	}
+
+	/**
+	 * A null byte cannot reach the filesystem calls. PHP rejects paths containing
+	 * one, but stripping it here means it never gets that far.
+	 */
+	public function test_null_byte_is_dropped(): void {
+		$this->assertSame( '/blog/x/', wpsc_sanitize_cache_path( "/blog/x\0/" ) );
+	}
+
+	/**
+	 * Backslashes go, so a Windows-style separator cannot be smuggled past the
+	 * '..' strip that runs on the result.
+	 */
+	public function test_backslashes_are_dropped(): void {
+		$this->assertSame( '/blog/..etc/', wpsc_sanitize_cache_path( '/blog/..\\etc/' ) );
+	}
+
+	/**
+	 * A colon is kept here and truncated later by the caller, which is where that
+	 * rule has always lived. This pins the division of labour.
+	 */
+	public function test_query_and_colon_handling(): void {
+		$this->assertSame( '/blog/x/idsomething', wpsc_sanitize_cache_path( '/blog/x/?id=something' ) );
+	}
+
+	/** An empty string is not a special case. */
+	public function test_empty_string(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( '' ) );
+	}
+}

--- a/tests/php/smoke/WpscSanitizeCachePathTest.php
+++ b/tests/php/smoke/WpscSanitizeCachePathTest.php
@@ -7,9 +7,10 @@
  * a supercache directory for a non-ASCII slug: /category/%d2%b1lytau/ arrived as
  * /category/lytau/ and realpath() found nothing. See #1081.
  *
- * The value is used to build a filesystem path, so the tests below cover both
- * halves of the job: keep what a URL path legitimately contains, drop everything
- * else.
+ * The value is used to build a filesystem path that a nonce has already been
+ * checked against, so the function returns the path or it returns nothing. The
+ * tests below cover both halves of that: keep what a URL path legitimately
+ * contains, reject the whole value otherwise.
  *
  * @package automattic/wp-super-cache
  */
@@ -36,49 +37,94 @@ class WpscSanitizeCachePathTest extends TestCase {
 		$this->assertSame( '/blog/hello-there/', wpsc_sanitize_cache_path( '/blog/hello-there/' ) );
 	}
 
-	/** The remaining characters a URL path can carry are all kept. */
+	/** The unreserved characters are all kept. */
 	public function test_other_path_characters_are_kept(): void {
 		$this->assertSame( '/a_b/c.d/~e-f/2026/', wpsc_sanitize_cache_path( '/a_b/c.d/~e-f/2026/' ) );
 	}
 
 	/**
-	 * Angle brackets, quotes and whitespace are dropped. The old
-	 * preg_replace() in wpsc_admin_bar_render() removed exactly these before the
-	 * value ever reached a nonce, and the allow-list keeps that guarantee.
+	 * The sub-delims and '@' are kept. get_current_url_supercache_dir() does not
+	 * strip these, so a directory on disk really can be named with them, and an
+	 * ActivityPub profile page at /@donncha/ is the obvious case.
 	 */
-	public function test_markup_and_whitespace_are_dropped(): void {
-		$this->assertSame( '/blog/scriptalert1/script/', wpsc_sanitize_cache_path( "/blog/<script>alert(1)</script>/\r\n" ) );
-		$this->assertSame( '/blog/one/', wpsc_sanitize_cache_path( '/blog/ one /' ) );
+	public function test_sub_delims_and_at_are_kept(): void {
+		$this->assertSame( '/@donncha/', wpsc_sanitize_cache_path( '/@donncha/' ) );
+		$this->assertSame( '/a!b/c$d/e&f/g*h/i+j/k,l/m;n/o=p/', wpsc_sanitize_cache_path( '/a!b/c$d/e&f/g*h/i+j/k,l/m;n/o=p/' ) );
+	}
+
+	/**
+	 * Raw bytes above \x7F are kept. A browser normally percent-encodes them, but
+	 * not always, and get_current_url_supercache_dir() passes them through, so a
+	 * directory can be spelled this way too.
+	 */
+	public function test_raw_utf8_is_kept(): void {
+		$this->assertSame( '/Ұlytau-oblysy/', wpsc_sanitize_cache_path( '/Ұlytau-oblysy/' ) );
+	}
+
+	/**
+	 * Anything off the allow-list rejects the whole value instead of being removed
+	 * from it. Stripping would leave a shorter path that still resolves, so the
+	 * delete would land on a real directory the nonce never covered.
+	 */
+	public function test_disallowed_characters_reject_the_whole_path(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( "/blog/<script>alert(1)</script>/\r\n" ) );
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/ one /' ) );
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/"quoted"/' ) );
 	}
 
 	/**
 	 * A null byte cannot reach the filesystem calls. PHP rejects paths containing
-	 * one, but stripping it here means it never gets that far.
+	 * one, but rejecting here means it never gets that far.
 	 */
-	public function test_null_byte_is_dropped(): void {
-		$this->assertSame( '/blog/x/', wpsc_sanitize_cache_path( "/blog/x\0/" ) );
+	public function test_null_byte_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( "/blog/x\0/" ) );
 	}
 
 	/**
-	 * Backslashes go, so a Windows-style separator cannot be smuggled past the
-	 * '..' strip that runs on the result.
+	 * A backslash is rejected, so a Windows-style separator cannot be smuggled
+	 * past the '..' strip that runs on the result.
 	 */
-	public function test_backslashes_are_dropped(): void {
-		$this->assertSame( '/blog/..etc/', wpsc_sanitize_cache_path( '/blog/..\\etc/' ) );
+	public function test_backslash_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/..\\etc/' ) );
 	}
 
 	/**
-	 * Colons go. wpsc_delete_cache_directory() truncates at ':' after calling
-	 * this, so that line now has nothing left to find, but it is kept as a guard
-	 * against this allow-list changing. Pinned here so the two stay in step.
+	 * ':' is rejected. wpsc_delete_cache_directory() truncates at ':' after
+	 * calling this, so that line now has nothing left to find, but it is kept as
+	 * a guard against this allow-list changing. Pinned here so the two stay in
+	 * step.
 	 */
-	public function test_colons_are_dropped(): void {
-		$this->assertSame( '/blog/x/8080/evil', wpsc_sanitize_cache_path( '/blog/x/:8080/evil' ) );
+	public function test_colon_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/x/:8080/evil' ) );
 	}
 
-	/** A query string loses the characters that make it one. */
-	public function test_query_string_punctuation_is_dropped(): void {
-		$this->assertSame( '/blog/x/idsomething', wpsc_sanitize_cache_path( '/blog/x/?id=something' ) );
+	/**
+	 * A query string is rejected rather than having its punctuation removed.
+	 * Dropping the '?s=foo' off a search page would leave '/', and the site root
+	 * is a real directory, so the delete would move to a page nobody asked to
+	 * clear.
+	 */
+	public function test_query_string_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/blog/x/?id=something' ) );
+		$this->assertSame( '', wpsc_sanitize_cache_path( '/?s=foo' ) );
+	}
+
+	/**
+	 * The anchor is \z, not $, so a trailing newline cannot ride along on an
+	 * otherwise valid path.
+	 */
+	public function test_trailing_newline_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( "/blog/hello-there/\n" ) );
+	}
+
+	/**
+	 * $_POST['path'] is an array if the request sends path[]=. wp_unslash() hands
+	 * that straight back, and a (string) cast on it would warn and produce the
+	 * literal 'Array'.
+	 */
+	public function test_non_string_input_is_rejected(): void {
+		$this->assertSame( '', wpsc_sanitize_cache_path( array( '/blog/' ) ) );
+		$this->assertSame( '', wpsc_sanitize_cache_path( null ) );
 	}
 
 	/** An empty string is not a special case. */

--- a/wp-cache-base.php
+++ b/wp-cache-base.php
@@ -8,6 +8,11 @@ if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
 	$WPSC_HTTP_HOST = htmlentities( $WPSC_HTTP_HOST, ENT_COMPAT );
 } elseif ( PHP_SAPI === 'cli' && function_exists( 'get_option' ) ) {
 	$WPSC_HTTP_HOST = (string) parse_url( get_option( 'home' ), PHP_URL_HOST );
+	// Lowercased like the branch above. The supercache directory is named after
+	// this, so a home option carrying uppercase would have WP-CLI and cron
+	// disagree with web requests about where the cache lives. See #1081.
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$WPSC_HTTP_HOST = function_exists( 'mb_strtolower' ) ? mb_strtolower( $WPSC_HTTP_HOST ) : strtolower( $WPSC_HTTP_HOST );
 } else {
 	$cache_enabled  = false;
 	$WPSC_HTTP_HOST = '';

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -882,7 +882,7 @@ function get_supercache_dir( $blog_id = 0 ) {
  * Order matters: lowercase first, then uppercase the escapes. Doing it the other
  * way round drags the escapes back down with the surrounding ASCII.
  *
- * @since 3.1.2
+ * @since $$next-version$$
  *
  * @param string $uri URI or path fragment.
  * @return string Normalised URI.
@@ -913,7 +913,7 @@ function wpsc_normalize_uri_case( $uri ) {
  * that do still matter run later: the '..' strip, wp_cache_confirm_delete(), and
  * the check that the resolved path sits inside the supercache directory.
  *
- * @since 3.1.2
+ * @since $$next-version$$
  *
  * @param string $path Path from the request.
  * @return string Path with anything that cannot appear in a URL path removed.

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -906,20 +906,43 @@ function wpsc_normalize_uri_case( $uri ) {
  * /category/%d2%b1lytau/ into /category/lytau/ and the deletion never found
  * anything. See #1081.
  *
- * An allow-list of the characters a URL path can use is enough here. ':' is not
- * on the list, so the truncation at ':' that wpsc_delete_cache_directory() does
- * afterwards no longer has anything to find; it is left in place because that
- * function should not depend on the exact shape of this allow-list. The guards
- * that do still matter run later: the '..' strip, wp_cache_confirm_delete(), and
- * the check that the resolved path sits inside the supercache directory.
+ * The allow-list is the pchar set of RFC 3986 section 3.3, less the characters
+ * that never reach a directory name anyway: ':' because no permalink uses it,
+ * and ' ( ) because wpsc_admin_bar_render() strips them from REQUEST_URI before
+ * building the link. Raw bytes above \x7F are allowed because
+ * get_current_url_supercache_dir() does not strip them either, so a directory on
+ * disk really can be named with them.
+ *
+ * Anything else means the whole value is rejected rather than cleaned up. A path
+ * with the offending characters removed is still a path, and it still resolves,
+ * so stripping would turn a delete of /@donncha/ into a delete of /donncha/ and
+ * point a nonce-checked operation at a directory the nonce never covered.
+ *
+ * A query string fails the allow-list for the same reason. Dropping the '?s=foo'
+ * off a search page would leave '/', which is the site root and a real directory.
+ *
+ * Rejecting means the truncation at ':' that wpsc_delete_cache_directory() does
+ * afterwards has nothing left to find; it is kept because that function should
+ * not depend on the exact shape of this allow-list. The guards that do still
+ * matter run later: the '..' strip, wp_cache_confirm_delete(), and the check that
+ * the resolved path sits inside the supercache directory.
  *
  * @since $$next-version$$
  *
  * @param string $path Path from the request.
- * @return string Path with anything that cannot appear in a URL path removed.
+ * @return string The path unchanged, or '' if it is not one.
  */
 function wpsc_sanitize_cache_path( $path ) {
-	return preg_replace( '#[^A-Za-z0-9%_./~-]#', '', (string) $path );
+	if ( ! is_string( $path ) ) {
+		return '';
+	}
+
+	// \z rather than $ so a trailing newline cannot slip past the anchor.
+	if ( ! preg_match( '#^[A-Za-z0-9%_.~!$&*+,;=@/\x80-\xFF-]*\z#', $path ) ) {
+		return '';
+	}
+
+	return $path;
 }
 
 function get_current_url_supercache_dir( $post_id = 0 ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -879,21 +879,33 @@ function get_supercache_dir( $blog_id = 0 ) {
  * send different strings for one page. Uppercase is the target because RFC 3986
  * section 2.1 recommends it and because it is the shape already on disk.
  *
- * Order matters: lowercase first, then uppercase the escapes. Doing it the other
- * way round drags the escapes back down with the surrounding ASCII.
+ * Escapes and unencoded ASCII are matched in one pass so neither can undo the
+ * other: lowercasing the whole string first and then uppercasing the escapes
+ * works too, but only in that order, and the alternation removes the trap.
+ *
+ * Only ASCII is touched. strtolower() on the whole string would be simpler, but
+ * it is locale-dependent before PHP 8.2 and this plugin supports 7.4, where a
+ * single-byte LC_CTYPE would lowercase bytes 0xC0-0xDE and corrupt a path that
+ * carries raw UTF-8. Matching [A-Z] keeps that out of reach on every version.
  *
  * @since $$next-version$$
  *
  * @param string $uri URI or path fragment.
- * @return string Normalised URI.
+ * @return string Normalised URI, or '' if $uri is not a string.
  */
 function wpsc_normalize_uri_case( $uri ) {
+	// Not a cast: the REST endpoint feeds this straight from get_json_params(),
+	// where 'url' can be an array, and "Array" is a plausible directory name.
+	if ( ! is_string( $uri ) ) {
+		return '';
+	}
+
 	return preg_replace_callback(
-		'/%[a-f0-9]{2}/',
+		'/%[0-9A-Fa-f]{2}|[A-Z]+/',
 		function ( $matches ) {
-			return strtoupper( $matches[0] );
+			return '%' === $matches[0][0] ? strtoupper( $matches[0] ) : strtolower( $matches[0] );
 		},
-		strtolower( (string) $uri )
+		$uri
 	);
 }
 
@@ -918,8 +930,15 @@ function wpsc_normalize_uri_case( $uri ) {
  * so stripping would turn a delete of /@donncha/ into a delete of /donncha/ and
  * point a nonce-checked operation at a directory the nonce never covered.
  *
- * A query string fails the allow-list for the same reason. Dropping the '?s=foo'
- * off a search page would leave '/', which is the site root and a real directory.
+ * '?' is on the list for that same reason, inverted. Supercache never names a
+ * directory after a query string, so a value carrying one simply fails to
+ * resolve and the delete is a no-op, which is what it has always been. Removing
+ * the '?s=foo' off a search page instead would leave '/', the site root, which
+ * is a real directory and very much not the one the nonce covered. Keeping the
+ * query is what makes it harmless. Rejecting the whole value is not an option
+ * here either: the admin bar renders this button on any URL, so on a site using
+ * plain permalinks every path is '/?p=123', and a rejected path takes the caller
+ * down a branch that reports a nonce failure that did not happen.
  *
  * Rejecting means the truncation at ':' that wpsc_delete_cache_directory() does
  * afterwards has nothing left to find; it is kept because that function should
@@ -938,11 +957,34 @@ function wpsc_sanitize_cache_path( $path ) {
 	}
 
 	// \z rather than $ so a trailing newline cannot slip past the anchor.
-	if ( ! preg_match( '#^[A-Za-z0-9%_.~!$&*+,;=@/\x80-\xFF-]*\z#', $path ) ) {
+	if ( ! preg_match( '#^[A-Za-z0-9%_.~!$&*+,;=@/?\x80-\xFF-]*\z#', $path ) ) {
 		return '';
 	}
 
 	return $path;
+}
+
+/**
+ * Supercache directory for an absolute URL.
+ *
+ * Pulled out of wp_cron_preload_cache() so the rule it applies can be tested.
+ * That caller deletes a directory and immediately refetches the page, so a delete
+ * that misses is served the stale file it was meant to replace, which made it the
+ * most damaging of the sites #1081 covers and the only one with no seam to test.
+ *
+ * wp_parse_url() omits 'path' entirely for a URL like 'https://example.com', so
+ * the fallback is not decoration; the old inline version emitted a notice there.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $url Absolute URL.
+ * @return string Supercache directory for $url, without a trailing slash.
+ */
+function wpsc_supercache_dir_for_url( $url ) {
+	$url_info = wp_parse_url( (string) $url );
+	$path     = isset( $url_info['path'] ) ? $url_info['path'] : '/';
+
+	return get_supercache_dir() . wpsc_normalize_uri_case( $path );
 }
 
 function get_current_url_supercache_dir( $post_id = 0 ) {
@@ -3420,7 +3462,10 @@ function wp_cache_post_id_gc( $post_id, $all = 'all' ) {
 		return true;
 	}
 
-	$permalink = trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( $post_id ) ) );
+	// Normalised so the gc_cache payload below is spelled the same way
+	// wp_cache_post_change() spells it. Consumers build a supercache path out of
+	// it, so the two firing sites disagreeing is a bug of its own. See #1081.
+	$permalink = wpsc_normalize_uri_case( trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( $post_id ) ) ) );
 	if ( str_contains( $permalink, '?' ) ) {
 		wp_cache_debug( 'wp_cache_post_id_gc: NOT CLEARING CACHE. Permalink has a "?". ' . $permalink );
 		return false;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1033,8 +1033,11 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 	$uri      = wpsc_deep_replace( array( '..', '\\', 'index.php' ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( '/(\?.*)?(#.*)?$/', '', $uri ) ) );
 	$hostname = $WPSC_HTTP_HOST;
 	// Get hostname from wp options for wp-cron, wp-cli and similar requests.
+	// Lowercased because $WPSC_HTTP_HOST already is, and the two have to name the
+	// same directory. See #1081.
 	if ( empty( $hostname ) && function_exists( 'get_option' ) ) {
 		$hostname = (string) parse_url( get_option( 'home' ), PHP_URL_HOST );
+		$hostname = function_exists( 'mb_strtolower' ) ? mb_strtolower( $hostname ) : strtolower( $hostname );
 	}
 	$dir = preg_replace( '/:.*$/', '', $hostname ) . $uri; // To avoid XSS attacks
 	if ( function_exists( 'apply_filters' ) ) {

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -869,6 +869,57 @@ function get_supercache_dir( $blog_id = 0 ) {
 	}
 	return trailingslashit( apply_filters( 'wp_super_cache_supercachedir', $cache_path . 'supercache/' . trailingslashit( strtolower( preg_replace( '/:.*$/', '', str_replace( 'http://', '', str_replace( 'https://', '', $home ) ) ) ) ) ) );
 }
+/**
+ * Normalise a URI to the spelling used by supercache directory names.
+ *
+ * Supercache directories are lowercase, with any percent escapes uppercased.
+ * The same path reaches us spelled two ways: sanitize_title_with_dashes()
+ * lowercases the escapes it stores in post_name, while a URL encoder emits them
+ * uppercase, so a visitor following a permalink and one pasting the unicode URL
+ * send different strings for one page. Uppercase is the target because RFC 3986
+ * section 2.1 recommends it and because it is the shape already on disk.
+ *
+ * Order matters: lowercase first, then uppercase the escapes. Doing it the other
+ * way round drags the escapes back down with the surrounding ASCII.
+ *
+ * @since 1.13.0
+ *
+ * @param string $uri URI or path fragment.
+ * @return string Normalised URI.
+ */
+function wpsc_normalize_uri_case( $uri ) {
+	return preg_replace_callback(
+		'/%[a-f0-9]{2}/',
+		function ( $matches ) {
+			return strtoupper( $matches[0] );
+		},
+		strtolower( (string) $uri )
+	);
+}
+
+/**
+ * Sanitise a cache path taken from the request.
+ *
+ * Deliberately not sanitize_text_field(): _sanitize_text_fields() strips every
+ * percent escape it finds, and a supercache directory for a non-ASCII slug is
+ * largely made of percent escapes, so that call quietly turned
+ * /category/%d2%b1lytau/ into /category/lytau/ and the deletion never found
+ * anything. See #1081.
+ *
+ * An allow-list of the characters a URL path can use is enough here. Everything
+ * that contains this value still applies afterwards: the '..' strip, the
+ * truncation at ':', wp_cache_confirm_delete(), and the check that the resolved
+ * path sits inside the supercache directory.
+ *
+ * @since 1.13.0
+ *
+ * @param string $path Path from the request.
+ * @return string Path with anything that cannot appear in a URL path removed.
+ */
+function wpsc_sanitize_cache_path( $path ) {
+	return preg_replace( '#[^A-Za-z0-9%_./~-]#', '', (string) $path );
+}
+
 function get_current_url_supercache_dir( $post_id = 0 ) {
 	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST, $wp_cache_home_path;
 	static $saved_supercache_dir = array();
@@ -911,15 +962,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$uri = $wp_cache_request_uri;
 	}
 
-	// Supercache directories are lowercase, with any percent escapes uppercased.
-	$uri      = strtolower( $uri );
-	$uri      = preg_replace_callback(
-		'/%[a-f0-9]{2}/',
-		function ( $matches ) {
-			return strtoupper( $matches[0] );
-		},
-		$uri
-	);
+	$uri      = wpsc_normalize_uri_case( $uri );
 	$uri      = wpsc_deep_replace( array( '..', '\\', 'index.php' ), preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', preg_replace( '/(\?.*)?(#.*)?$/', '', $uri ) ) );
 	$hostname = $WPSC_HTTP_HOST;
 	// Get hostname from wp options for wp-cron, wp-cli and similar requests.
@@ -1398,7 +1441,9 @@ function wpsc_delete_url_cache( $url ) {
 		wp_cache_debug( 'wpsc_delete_url_cache: URL contains the character "?". Not deleting URL: ' . $url );
 		return false;
 	}
-	$dir = str_replace( get_option( 'home' ), '', $url );
+	// $url is a WordPress-generated permalink, so its percent escapes are
+	// lowercase while the directory on disk has them uppercased. See #1081.
+	$dir = wpsc_normalize_uri_case( str_replace( get_option( 'home' ), '', $url ) );
 	if ( $dir != '' ) {
 		$supercachedir = get_supercache_dir();
 		wpsc_rebuild_files( $supercachedir . $dir );
@@ -3236,8 +3281,11 @@ function wpsc_delete_cats_tags( $post ) {
 		}
 		$category_base = trailingslashit( $category_base ); // paranoid much?
 		foreach ( $categories as $cat ) {
-			prune_super_cache( get_supercache_dir() . $category_base . $cat->slug . '/', true );
-			wp_cache_debug( 'wpsc_post_transition: deleting category: ' . get_supercache_dir() . $category_base . $cat->slug . '/' );
+			// Term slugs are stored with lowercase percent escapes; the directory
+			// on disk has them uppercased. See #1081.
+			$cat_dir = get_supercache_dir() . wpsc_normalize_uri_case( $category_base . $cat->slug ) . '/';
+			prune_super_cache( $cat_dir, true );
+			wp_cache_debug( 'wpsc_post_transition: deleting category: ' . $cat_dir );
 		}
 	}
 	$posttags = get_the_tags( $post->ID );
@@ -3248,8 +3296,9 @@ function wpsc_delete_cats_tags( $post ) {
 		}
 		$tag_base = trailingslashit( str_replace( '..', '', $tag_base ) ); // maybe!
 		foreach ( $posttags as $tag ) {
-			prune_super_cache( get_supercache_dir() . $tag_base . $tag->slug . '/', true );
-			wp_cache_debug( 'wpsc_post_transition: deleting tag: ' . get_supercache_dir() . $tag_base . $tag->slug . '/' );
+			$tag_dir = get_supercache_dir() . wpsc_normalize_uri_case( $tag_base . $tag->slug ) . '/';
+			prune_super_cache( $tag_dir, true );
+			wp_cache_debug( 'wpsc_post_transition: deleting tag: ' . $tag_dir );
 		}
 	}
 }

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -882,7 +882,7 @@ function get_supercache_dir( $blog_id = 0 ) {
  * Order matters: lowercase first, then uppercase the escapes. Doing it the other
  * way round drags the escapes back down with the surrounding ASCII.
  *
- * @since 1.13.0
+ * @since 3.1.2
  *
  * @param string $uri URI or path fragment.
  * @return string Normalised URI.
@@ -906,12 +906,14 @@ function wpsc_normalize_uri_case( $uri ) {
  * /category/%d2%b1lytau/ into /category/lytau/ and the deletion never found
  * anything. See #1081.
  *
- * An allow-list of the characters a URL path can use is enough here. Everything
- * that contains this value still applies afterwards: the '..' strip, the
- * truncation at ':', wp_cache_confirm_delete(), and the check that the resolved
- * path sits inside the supercache directory.
+ * An allow-list of the characters a URL path can use is enough here. ':' is not
+ * on the list, so the truncation at ':' that wpsc_delete_cache_directory() does
+ * afterwards no longer has anything to find; it is left in place because that
+ * function should not depend on the exact shape of this allow-list. The guards
+ * that do still matter run later: the '..' strip, wp_cache_confirm_delete(), and
+ * the check that the resolved path sits inside the supercache directory.
  *
- * @since 1.13.0
+ * @since 3.1.2
  *
  * @param string $path Path from the request.
  * @return string Path with anything that cannot appear in a URL path removed.
@@ -3508,7 +3510,7 @@ function wp_cache_post_change( $post_id ) {
 			 */
 			wp_cache_debug( 'Post change: page_for_posts ' . get_option( 'page_for_posts' ), 4 );
 			if ( get_option( 'page_for_posts' ) ) {
-				$permalink = trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( get_option( 'page_for_posts' ) ) ) );
+				$permalink = wpsc_normalize_uri_case( trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( get_option( 'page_for_posts' ) ) ) ) );
 				wp_cache_debug( 'Post change: Deleting files in: ' . str_replace( '//', '/', $dir . $permalink ) );
 				wpsc_rebuild_files( $dir . $permalink );
 				do_action( 'gc_cache', 'prune', $permalink );
@@ -3538,7 +3540,7 @@ function wp_cache_post_change( $post_id ) {
 						continue;
 					}
 					if ( $post_id > 0 && $meta ) {
-						$permalink = trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( $post_id ) ) );
+						$permalink = wpsc_normalize_uri_case( trailingslashit( str_replace( get_option( 'home' ), '', get_permalink( $post_id ) ) ) );
 						if ( $meta['blog_id'] == $blog_id && ( ( $all == true && ! $meta['post'] ) || $meta['post'] == $post_id ) ) {
 							wp_cache_debug( "Post change: deleting post wp-cache files for {$meta[ 'uri' ]}: $file", 4 );
 							@unlink( $blog_cache_dir . 'meta/' . $file );


### PR DESCRIPTION
Fixes #1081. Follow-up to #1080, which fixed the same bug for a post's own cache directory.

Supercache directory names are lowercase with any percent escapes uppercased. WordPress stores a non-ASCII slug the other way round, lowercase, because `sanitize_title_with_dashes()` lowercases what `utf8_uri_encode()` built with `dechex()`. So `get_term_link()` hands us `/category/%d2%b1lytau-oblysy/` while the directory on disk is `/category/%D2%B1lytau-oblysy/`, nothing matches, and nothing is deleted. Edit a post in a category with a Cyrillic or Kazakh slug and the category page keeps serving the old version.

Only `get_current_url_supercache_dir()` knew the rule. Every other path built its own and got it wrong.

### The fix

`wpsc_normalize_uri_case()` in wp-cache-phase2.php: lowercase, then uppercase the escapes. That order matters, the other way round drags the escapes back down with the surrounding ASCII.

Called from the four places #1081 listed, plus two it did not:

- `wpsc_delete_url_cache()`, which covers taxonomy archives, post type archives, author archives, and `wpsc_delete_post_cache()` behind the REST endpoint
- `wp_cron_preload_cache()`, the worst of them, because it deletes and then immediately refetches. A miss means the fetch is served the stale file still sitting there, so a taxonomy archive with a non-ASCII slug was never refreshed by preload at all
- `wpsc_delete_cache_directory()`, the admin bar and REST delete button
- `$home_root_lc` in `wpsc_get_htaccess_info()`, which was already lowercasing by hand for the same convention
- `wpsc_delete_cats_tags()`, deprecated but still callable, which builds its paths from `$cat->slug` directly
- `wp_cache_post_change()`, in two places, for the posts page and the legacy wp-cache meta cleanup

The last two are not in the issue. I found the deprecated one while reading, and a review pass caught the `wp_cache_post_change()` pair after I had convinced myself I was done. Worth saying out loud, because I had traced the deletion paths through `wpsc_delete_url_cache()` and stopped there, and those two build the path inline.

### A second bug in the delete cache button

Normalising the case in `wpsc_delete_cache_directory()` did not work, and it took me a while to see why.

The path arrives through `sanitize_text_field()`, and `_sanitize_text_fields()` strips every `%xx` escape it finds. So `/category/%d2%b1lytau-oblysy/` was already `/category/lytau-oblysy/` before we saw it, `realpath()` returned false, and the function fell out of its else branch having done nothing. The delete cache button has never been able to clear a cache directory for a non-ASCII slug, for a reason that has nothing to do with case.

So the fix #1081 suggested for that call site was necessary but not sufficient. `wpsc_sanitize_cache_path()` replaces it, an allow-list of the characters a URL path can use. Everything that made that value safe still runs afterwards: the `..` strip, `wp_cache_confirm_delete()`, `wpsc_is_in_cache_directory()`, and the check that the resolved path sits inside the supercache directory. `%2e%2e%2f` is not decoded before `realpath()`, so encoded traversal fails closed the same way it did before. Registered as a `customSanitizingFunctions` entry so PHPCS knows what it is.

Also swapped `stripslashes()` for `wp_unslash()` on the two lines I was touching anyway. `stripslashes()` throws on an array, which `$_POST['path']` can be if someone posts `path[]=`.

### Two things I did not do

The issue says the helper lets `SupercacheDirCaseTest` shed its reflection precondition. It does not. That guard is there because `get_current_url_supercache_dir()` memoises into a static keyed by `$post_id` with no way to reset it, and extracting a pure helper elsewhere does not change that. Left it alone.

There is no author archive test. `get_author_posts_url()` builds from `user_nicename`, and WordPress runs that through `sanitize_user( $nicename, true )`, which strips percent escapes. `sanitize_title( 'Ұlytau oblysy' )` gives `%d2%b1lytau-oblysy` and the stored nicename comes back `lytau-oblysy`. WordPress will not produce such a nicename through its own API, so reproducing it means writing the row by hand, which tests a state that does not occur. I have covered `wpsc_delete_post_cache()` instead. The issue title says author URLs are affected and I do not think that is right, so I will correct it there.

The two `wp_cache_post_change()` call sites are fixed but not covered by a test. That function has its own unresettable `static $last_processed` and needs legacy wp-cache meta files on disk to reach the second branch, and the setup cost is out of proportion to the one-line change.

### Testing

Both helpers are pure, so their tests are in the smoke tier. That is the point of the extraction: CI runs `composer test-php` and nothing else, so the integration tests added in #1080 only run when somebody types `make test-integration`. This is where the rule finally gets covered on every push.

- `composer test-php`, 53 tests, green
- `make test-integration`, 45 tests and 119 assertions, green
- `DeleteUrlCacheCaseTest` builds its fixtures with the helper, so it also asserts the raw and normalised paths differ. Otherwise it would pass for the wrong reason. I reverted the normalisation at each call site and confirmed all five tests fail
- phpcs clean on every changed line, and on the three new test files

One thing worth knowing if you write term tests here: `WP_Rewrite::init()` clears `extra_permastructs`, and only `create_initial_taxonomies()` puts the taxonomy ones back. Without it `set_permalink_structure()` leaves `get_term_link()` returning `?cat=N`, and a test that looks like it is exercising pretty permalinks quietly is not.

### Release Notes

- Fix: clear the cache for category, tag and archive pages whose slug contains non-ASCII characters. The delete cache button could not clear those pages either, and now can.

### Review round

A review pass found one thing I had got properly wrong and a few smaller ones.

**The delete cache button broke on any URL with a query string.** The allow-list rejected `?`, and an empty path short-circuits the nonce guard, so the caller read that as a nonce failure and died with a message blaming the nonce. On a site using plain permalinks every path is `/?p=123`, so the button was a dead end there, and on search pages too. It used to be a silent no-op and I turned it into an error page.

`?` is on the list now, and the reasoning inverts nicely. Keeping the query is what makes it harmless: supercache never names a directory after one, so the path fails to resolve and the delete does nothing, which is what it always did. Trimming the `?s=foo` off a search page is the dangerous move, because that leaves `/`, the site root, and that is a real directory the nonce never covered. The docblock already said so about stripping; it just did not follow that through to rejecting.

**The REST endpoint is the one caller that hands these helpers raw JSON**, where `url` can be an array. `wpsc_normalize_uri_case()` still had a `(string)` cast, which would have made that the directory `Array`, so it now guards on `is_string()` the way its sibling does, and the endpoint runs its url through `wpsc_sanitize_cache_path()` and returns a 400 for what it cannot use. Traversal already failed closed there, since `wpsc_delete_files()` refuses the protected paths, but relying on that was not obvious to read.

**Two more call sites.** `wp_cache_post_id_gc()` builds the same permalink expression and fires the same `gc_cache` action as `wp_cache_post_change()`, so normalising only the latter left one action emitting two spellings, and the shipped domain mapping plugin builds a supercache path straight out of that payload. And the direct page delete in `inc/settings-forms.php`. That is four call sites this PR found that the issue did not list, which says something about how the convention was spread around.

**`wpsc_normalize_uri_case()` only touches ASCII now.** `strtolower()` on the whole string is locale-dependent before PHP 8.2, and `readme.txt` says the plugin supports 7.4, where a single-byte `LC_CTYPE` lowercases 0xC0-0xDE and would corrupt raw UTF-8 in a path. Harmless in practice, because both sides of the comparison mangled it identically, but the test docblock stated it as a plain property of `strtolower()` and that was not true on every supported version. Matching `[A-Z]` instead makes the claim hold everywhere, and there is a test that pins it under a single-byte locale.

**`wpsc_supercache_dir_for_url()`**, pulled out of `wp_cron_preload_cache()`. That was the site I called the worst one and the only one with no seam to test. It also emitted a notice for a URL with no path, since `wp_parse_url()` omits the key entirely.

New tests for all of it: the query string regression, the REST url branch, the preload seam, non-string input, and one asserting `%2e%2e%2f` passes through undecoded. That last one is a security property resting on `realpath()` not percent-decoding, and it was recorded only in a commit message before.

The integration teardown no longer removes `supercache` wholesale. `set_up_before_class()` may adopt a `cache_path` it did not create, and in a wp-env run that is the site's real `wp-content/cache`.

**Domain mapping.** `domain_mapping_supercachedir()` and `domain_mapping_gc_cache()` both build the cache directory from `domain_mapping_siteurl()` and kept whatever case it returned. The serving side does not: `get_current_url_supercache_dir()` builds its host segment from `$WPSC_HTTP_HOST`, which `wp-cache-base.php` lowercases. So a mapped domain carrying any uppercase was written to one directory and looked for in another, which is this same bug one level up from the path. Fixed here since it is the same normalisation, and it is what makes the now-consistent `gc_cache` payload any use.

No test for that one. Both functions return early unless the domain mapping plugin itself is present, and stubbing `domain_mapping_warning()` into the process to get past that would leave `function_exists()` true for every test after it.

**The same thing on the WP-CLI and cron path.** `$WPSC_HTTP_HOST` is empty there, and both fallbacks read the host out of the home option without lowercasing it, while `wp-cache-base.php` lowercases the `HTTP_HOST` it uses for a web request and `get_supercache_dir()` lowercases too. So an install whose home option carries uppercase had its cron and CLI requests name a different supercache directory than its web requests did. Two sites: `wp-cache-base.php` and the same fallback inside `get_current_url_supercache_dir()`.

That one is tested. The test filters `option_home` rather than saving it, because `WP_HOME` is defined in the test config and core's `_config_wp_home()` puts that back at priority 10, so a stored value never survives to be read. It also stays clear of the memoised static: a home option that `site_url()` does not appear in sends the function down its `DONOTREMEMBER` branch, which leaves key 0 free for the test that needs it.

Between them these three host fixes are the same defect as the path one, a level up. The path and the host segment are built by different code with different spelling rules, and only the path half had been made consistent.

- `composer test-php`, 60 tests, green
- `make test-integration`, 51 tests and 136 assertions, green
- the two new integration tests were confirmed to fail with the fix reverted

### Manually tested

On a wp-env site running WordPress 7.0.4, in Simple mode.

- A category named `Ұlytau oblysy` caches to `%D2%B1lytau-oblysy` on disk, uppercase escapes against the lowercase slug in the database, and clears when a post in it is edited. This is the reported bug.
- The delete cache button clears that category. It has never been able to do that in a released version.
- Preload refreshes it, rather than deleting nothing and then being served the stale file it was meant to replace.
- The button still works normally on an ordinary post permalink, and editing a page with a plain ASCII permalink clears its cache as before. Every change here has to be a byte-for-byte no-op for an all-lowercase ASCII path, and that is the check that says so.
- On `/?p=123` it does nothing, which is the point. `get_current_url_supercache_dir()` strips the query when it builds a directory name, so trimming the query here would resolve to `/` and delete the homepage cache instead. On plain permalinks that would happen on every click.
- Clearing from WP-CLI works. That is the path where `$WPSC_HTTP_HOST` is empty and the host comes from the home option.

One thing that came up and is deliberately not addressed here. On a URL like `/some-post/?utm_source=x` the button appears to do nothing, because `wpsc_is_get_query()` stops WP Super Cache serving a supercache file for any URL carrying a query string. What serves that request is the legacy wp-cache file keyed on the full URL, and the button only ever deletes supercache directories. Same behaviour in 3.1.1, so not a regression, but "delete cache of the current page" not clearing what is actually serving the current page deserves its own issue.

Not manually tested: domain mapping, which needs multisite plus the MU Domain Mapping plugin, and the REST `url` branch.


