### PR TITLE
Do not build a supercache path the filesystem cannot accept

### DIFF
--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -46,6 +46,9 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 			'wp_cache_home_path'   => '/',
 			'wp_cache_request_uri' => '/',
 			'cached_direct_pages'  => array(),
+			// Snapshotted because the overlong-path guard switches these off.
+			'cache_enabled'        => true,
+			'super_cache_enabled'  => true,
 		);
 
 		$this->saved_globals = array();
@@ -108,6 +111,34 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An overlong path switches caching off for the request, so nothing is ever
+	 * written to the placeholder directory and no two long URLs can share it.
+	 *
+	 * Declared first on purpose. It needs the $post_id = 0 branch, which the test
+	 * below also needs, and only one test per run may memoise key 0. This one is
+	 * safe to pair with it because the guard returns before the memoise, so it
+	 * leaves the key free. Reverse the order and this fails rather than passing
+	 * quietly, which is what the precondition is for.
+	 */
+	public function test_a_path_too_long_for_the_filesystem_disables_caching() {
+		$this->assertRequestUriBranchNotMemoised();
+
+		$GLOBALS['cache_enabled']       = true;
+		$GLOBALS['super_cache_enabled'] = true;
+
+		// Sized from the platform limit: 1024 on macOS, 4096 on Linux, which is
+		// what CI and the wp-env container run.
+		$GLOBALS['wp_cache_request_uri'] = '/' . str_repeat( 'b', PHP_MAXPATHLEN ) . '/';
+
+		get_current_url_supercache_dir( 0 );
+
+		$this->assertFalse( $GLOBALS['cache_enabled'], 'Caching has to be off, or the placeholder directory gets written to.' );
+		$this->assertFalse( $GLOBALS['super_cache_enabled'] );
+
+		$this->assertRequestUriBranchNotMemoised();
+	}
+
+	/**
 	 * The deletion branch has to land on the same directory the serving branch
 	 * creates. This is the regression from the bug report.
 	 *
@@ -147,6 +178,38 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 		preg_match_all( '/%[0-9a-fA-F]{2}/', $dir, $matches );
 		$this->assertNotEmpty( $matches[0], "Expected percent escapes in {$dir}." );
 		$this->assertSame( array_map( 'strtoupper', $matches[0] ), $matches[0] );
+	}
+
+	/**
+	 * A path the filesystem cannot accept is never handed back to a caller.
+	 *
+	 * Every filesystem call made with an overlong path emits a PHP warning, and
+	 * `wpcache_do_rebuild( get_current_url_supercache_dir() )` runs on more or
+	 * less every cacheable GET, so an error log fills up with them. See #1085.
+	 *
+	 * The two obvious answers are both worse than the bug. Truncating maps two
+	 * different URLs onto one directory, so the wrong page gets served. Returning
+	 * an empty string turns supercache_filename() into the relative path
+	 * 'index.html', which file_exists() may well find in the WordPress root. So
+	 * the function returns a short absolute path inside the cache directory that
+	 * nothing writes to, having switched caching off for the request.
+	 *
+	 * Driven through $wp_cache_home_path rather than a long slug, because
+	 * post_name is capped well below the limit. Uses a fresh post ID, so it does
+	 * not compete for the memoised key 0.
+	 */
+	public function test_a_path_too_long_for_the_filesystem_is_not_returned() {
+		$GLOBALS['wp_cache_home_path'] = '/' . str_repeat( 'a', PHP_MAXPATHLEN ) . '/';
+
+		list( $post_id ) = $this->publish( 'Hello There' );
+
+		$dir = get_current_url_supercache_dir( $post_id );
+
+		$this->assertNotSame( '', $dir, 'An empty path would be resolved relative to the working directory.' );
+		$this->assertFalse( wpsc_path_is_too_long( $dir ), "Returned path is still too long: {$dir}" );
+		$this->assertStringStartsWith( $GLOBALS['cache_path'], $dir, 'The path has to stay inside the cache directory.' );
+		$this->assertStringContainsString( WPSC_PATH_TOO_LONG_DIR, $dir );
+		$this->assertStringNotContainsString( str_repeat( 'a', 64 ), $dir, 'The long URI must not survive into the result, truncated or otherwise.' );
 	}
 
 	/**

--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -213,6 +213,11 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 		$this->assertFalse( wpsc_path_is_too_long( $dir ), "Returned path is still too long: {$dir}" );
 		$this->assertStringStartsWith( $GLOBALS['cache_path'], $dir, 'The path has to stay inside the cache directory.' );
 		$this->assertStringContainsString( WPSC_PATH_TOO_LONG_DIR, $dir );
+		$this->assertStringNotContainsString(
+			'supercache/',
+			$dir,
+			'The placeholder has to stay out of supercache/, where the first segment is named after the Host header and a request could claim it.'
+		);
 		$this->assertStringNotContainsString( str_repeat( 'a', 64 ), $dir, 'The long URI must not survive into the result, truncated or otherwise.' );
 	}
 

--- a/tests/php/integration/SupercacheDirCaseTest.php
+++ b/tests/php/integration/SupercacheDirCaseTest.php
@@ -199,12 +199,16 @@ class SupercacheDirCaseTest extends WP_UnitTestCase {
 	 * not compete for the memoised key 0.
 	 */
 	public function test_a_path_too_long_for_the_filesystem_is_not_returned() {
-		$GLOBALS['wp_cache_home_path'] = '/' . str_repeat( 'a', PHP_MAXPATHLEN ) . '/';
+		$GLOBALS['wp_cache_home_path']  = '/' . str_repeat( 'a', PHP_MAXPATHLEN ) . '/';
+		$GLOBALS['cache_enabled']       = true;
+		$GLOBALS['super_cache_enabled'] = true;
 
 		list( $post_id ) = $this->publish( 'Hello There' );
 
 		$dir = get_current_url_supercache_dir( $post_id );
 
+		$this->assertTrue( $GLOBALS['cache_enabled'], 'The deletion branch must not switch caching off for the admin request that is saving the post.' );
+		$this->assertTrue( $GLOBALS['super_cache_enabled'] );
 		$this->assertNotSame( '', $dir, 'An empty path would be resolved relative to the working directory.' );
 		$this->assertFalse( wpsc_path_is_too_long( $dir ), "Returned path is still too long: {$dir}" );
 		$this->assertStringStartsWith( $GLOBALS['cache_path'], $dir, 'The path has to stay inside the cache directory.' );

--- a/tests/php/smoke/WpscPathIsTooLongTest.php
+++ b/tests/php/smoke/WpscPathIsTooLongTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Smoke tests for wpsc_path_is_too_long().
+ *
+ * PHP emits "File name is longer than the maximum allowed path length on this
+ * platform" from every filesystem call made with an overlong path, which fills an
+ * error log with warnings. A malformed srcset gets a browser to request the whole
+ * attribute as a single URL, and a long URL on a site with a deep cache_path
+ * arrives at the same place. See #1085.
+ *
+ * The helper is pure, so it belongs in the smoke tier, which is the one CI runs.
+ *
+ * @package automattic/wp-super-cache
+ */
+
+// wp-cache-phase2.php is loaded by the smoke bootstrap (tests/php/bootstrap-smoke.php).
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ::wpsc_path_is_too_long
+ */
+class WpscPathIsTooLongTest extends TestCase {
+
+	/** Bytes of headroom the helper reserves for the filename appended to a directory. */
+	const HEADROOM = 64;
+
+	/**
+	 * The platform limit the helper measures against.
+	 *
+	 * @return int
+	 */
+	private function max_path() {
+		return defined( 'PHP_MAXPATHLEN' ) ? PHP_MAXPATHLEN : 1024;
+	}
+
+	/** An ordinary cache path is fine. */
+	public function test_a_normal_path_is_accepted(): void {
+		$this->assertFalse( wpsc_path_is_too_long( '/var/www/wp-content/cache/supercache/example.com/hello-there/' ) );
+	}
+
+	/** An empty string is not too long. */
+	public function test_empty_string_is_accepted(): void {
+		$this->assertFalse( wpsc_path_is_too_long( '' ) );
+	}
+
+	/**
+	 * The reported case: a srcset requested as a URL. Roughly the shape from
+	 * #1085, where the whole attribute becomes one path.
+	 */
+	public function test_a_srcset_sized_path_is_rejected(): void {
+		$prefix = '/data/www/25451/feedit_cz/www/wp-content/cache/supercache/feedit.cz/wp-content/uploads/2026/03/';
+		$chunk  = 'zastupci-ceskych-firem-pred-autonomnim-katamaranem-1024x768.jpeg%201024w,%20https:/feedit.cz/';
+
+		// Sized from the platform limit rather than a fixed count. PHP_MAXPATHLEN is
+		// 1024 on macOS, which is what the report shows, but 4096 on Linux, which is
+		// what CI runs. A hardcoded length passes on one and fails on the other.
+		$path = $prefix . str_repeat( $chunk, (int) ceil( $this->max_path() / strlen( $chunk ) ) + 1 );
+
+		$this->assertGreaterThan( $this->max_path(), strlen( $path ), 'Fixture is not actually overlong.' );
+		$this->assertTrue( wpsc_path_is_too_long( $path ) );
+	}
+
+	/**
+	 * Right at the limit. A path that fits exactly is still rejected, because a
+	 * filename gets appended to it before anything touches the filesystem.
+	 */
+	public function test_the_headroom_is_reserved(): void {
+		$exactly_at_limit = str_repeat( 'a', $this->max_path() );
+		$this->assertTrue( wpsc_path_is_too_long( $exactly_at_limit ) );
+
+		$fits_with_headroom = str_repeat( 'a', $this->max_path() - self::HEADROOM );
+		$this->assertFalse( wpsc_path_is_too_long( $fits_with_headroom ) );
+
+		$one_over = str_repeat( 'a', $this->max_path() - self::HEADROOM + 1 );
+		$this->assertTrue( wpsc_path_is_too_long( $one_over ) );
+	}
+
+	/**
+	 * Measured in bytes, not characters. A path of raw UTF-8 is longer on disk
+	 * than a naive character count suggests, and the filesystem counts bytes.
+	 */
+	public function test_length_is_measured_in_bytes(): void {
+		// 'Ұ' is two bytes, so this is under the limit by character count and over
+		// it by byte count. The filesystem cares about the latter.
+		$chars = (int) floor( ( $this->max_path() - self::HEADROOM ) * 0.75 );
+		$path  = str_repeat( 'Ұ', $chars );
+
+		$this->assertLessThan( $this->max_path(), mb_strlen( $path ) );
+		$this->assertTrue( wpsc_path_is_too_long( $path ) );
+	}
+}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -965,6 +965,40 @@ function wpsc_sanitize_cache_path( $path ) {
 }
 
 /**
+ * Directory name returned in place of a supercache path that will not fit.
+ *
+ * Nothing is ever written here: get_current_url_supercache_dir() switches caching
+ * off for the request at the same time it returns this. It exists so callers get
+ * an absolute path inside the cache directory rather than a truncated one or an
+ * empty string, both of which are worse. See wpsc_path_is_too_long().
+ */
+define( 'WPSC_PATH_TOO_LONG_DIR', '.wpsc-path-too-long' );
+
+/**
+ * Whether a path is too long for the filesystem to accept.
+ *
+ * PHP emits "File name is longer than the maximum allowed path length on this
+ * platform" from every filesystem call made with such a path, so an error log can
+ * fill up with them. Two ways to get there: a malformed srcset makes a browser
+ * request the whole attribute as one URL, and a genuinely long URL on a site
+ * whose cache_path is already deep spends the budget before the URI is added.
+ * See #1085.
+ *
+ * The headroom is because callers append a filename to the directory this
+ * measures, 'index.html' or 'meta-<32 hex chars>.meta' being the long ones.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $path Path to measure.
+ * @return bool True if the path cannot be used.
+ */
+function wpsc_path_is_too_long( $path ) {
+	$max = defined( 'PHP_MAXPATHLEN' ) ? PHP_MAXPATHLEN : 1024;
+
+	return ( strlen( (string) $path ) + 64 ) > $max;
+}
+
+/**
  * Supercache directory for an absolute URL.
  *
  * Pulled out of wp_cron_preload_cache() so the rule it applies can be tested.
@@ -989,6 +1023,7 @@ function wpsc_supercache_dir_for_url( $url ) {
 
 function get_current_url_supercache_dir( $post_id = 0 ) {
 	global $cached_direct_pages, $cache_path, $wp_cache_request_uri, $WPSC_HTTP_HOST, $wp_cache_home_path;
+	global $cache_enabled, $super_cache_enabled;
 	static $saved_supercache_dir = array();
 
 	if ( isset( $saved_supercache_dir[ $post_id ] ) ) {
@@ -1050,6 +1085,24 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		$dir = ABSPATH . $uri . '/';
 	}
 	$dir = str_replace( '..', '', str_replace( '//', '/', $dir ) );
+
+	if ( wpsc_path_is_too_long( $dir ) ) {
+		wp_cache_debug( 'get_current_url_supercache_dir: path is ' . strlen( $dir ) . ' bytes, too long for this platform. Not caching this request.' );
+
+		/*
+		 * Only the $post_id = 0 branch describes the request being served. The
+		 * other branch is used by the deletion paths, and switching caching off
+		 * there would disable it for whatever admin request happened to be
+		 * saving a post.
+		 */
+		if ( 0 === $post_id ) {
+			$cache_enabled       = false;
+			$super_cache_enabled = false;
+		}
+
+		return $cache_path . 'supercache/' . WPSC_PATH_TOO_LONG_DIR . '/';
+	}
+
 	wp_cache_debug( "supercache dir: $dir", 5 );
 	if ( $DONOTREMEMBER == 0 ) {
 		$saved_supercache_dir[ $post_id ] = $dir;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -971,6 +971,13 @@ function wpsc_sanitize_cache_path( $path ) {
  * off for the request at the same time it returns this. It exists so callers get
  * an absolute path inside the cache directory rather than a truncated one or an
  * empty string, both of which are worse. See wpsc_path_is_too_long().
+ *
+ * It sits directly under $cache_path, not under supercache/, because the first
+ * segment there is named after the request hostname and $WPSC_HTTP_HOST is
+ * whatever Host header arrived. A request carrying this name as its host would
+ * otherwise cache a real page into the directory, and the serving path reads the
+ * placeholder even though the writing path does not, so that page would then be
+ * served for every URL too long to build a path from.
  */
 define( 'WPSC_PATH_TOO_LONG_DIR', '.wpsc-path-too-long' );
 
@@ -1109,7 +1116,7 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 			$super_cache_enabled = false;
 		}
 
-		return $cache_path . 'supercache/' . WPSC_PATH_TOO_LONG_DIR . '/';
+		return $cache_path . WPSC_PATH_TOO_LONG_DIR . '/';
 	}
 
 	wp_cache_debug( "supercache dir: $dir", 5 );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1097,6 +1097,12 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 		 * other branch is used by the deletion paths, and switching caching off
 		 * there would disable it for whatever admin request happened to be
 		 * saving a post.
+		 *
+		 * Both flags have to go. wp_cache_shutdown_callback() writes the legacy
+		 * meta file into this same directory and gates that on $cache_enabled
+		 * alone, so clearing only $super_cache_enabled would leave the
+		 * placeholder being written to, which is the one thing it relies on not
+		 * happening.
 		 */
 		if ( 0 === $post_id ) {
 			$cache_enabled       = false;

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1026,6 +1026,9 @@ function get_current_url_supercache_dir( $post_id = 0 ) {
 	global $cache_enabled, $super_cache_enabled;
 	static $saved_supercache_dir = array();
 
+	// Normalised once so the branch test below and the too-long guard agree on what zero is.
+	$post_id = (int) $post_id;
+
 	if ( isset( $saved_supercache_dir[ $post_id ] ) ) {
 		return $saved_supercache_dir[ $post_id ];
 	}


### PR DESCRIPTION
Fixes #1085.

An error log filling up with `is_dir(): File name is longer than the maximum allowed path length on this platform (1024)`, pointed at `wpcache_do_rebuild()`.

The reported path is a whole `srcset` attribute being used as a URL: `%20` are browser-encoded spaces, `,` separates the candidates, `1024w` and `300w` are width descriptors. A malformed image tag gets the browser to request the entire attribute as one URL. The giveaway that it went through our code is `https:/host` with a single slash, which is `get_current_url_supercache_dir()`'s own `str_replace( '//', '/', $dir )`.

That is not the only way in. A genuinely long URL on a site whose `cache_path` is already deep gets there too, and that case matters more, because it is a real page.

`wpcache_do_rebuild( get_current_url_supercache_dir() )` runs on more or less every cacheable GET, so the warning repeats for every hit. The serving path's `file_exists()` calls warn the same way for the same request.

### The fix

`get_current_url_supercache_dir()` measures the path it has built. If it will not fit, it logs, switches caching off for the request, and returns a short placeholder inside the cache directory.

The two shorter answers are both worse than the bug, which is worth writing down so nobody simplifies it back:

- **Truncating** maps two different long URLs onto one directory, so the wrong page gets served. That is the writer/deleter mismatch #1084 just finished clearing out.
- **Returning `''`** turns `supercache_filename()` into the relative path `index.html` at `wp-cache-phase2.php:193`, which `file_exists()` may well find in the WordPress root.

Nothing is ever written to the placeholder, because caching is already off by the time it is returned, so two long URLs cannot come to share it.

Caching is only switched off on the `$post_id = 0` branch. That branch is the request being served. The other one belongs to the deletion paths, and disabling caching there would turn it off for whatever admin request happened to be saving a post.

### What this does not do

It does not cache long URLs. They are not cached today either, since the write fails the same way, so this is not a regression, but it is not an improvement on that front.

Hashing the tail would cache them properly. The catch is that the deleters do not call this function, so a hash known only to the writer would produce a page that caches forever and no edit could clear. Doing it safely means routing all nine path builders through one shared helper, which is the refactor already noted in the #1084 review. Follow-up, not this PR.

### Testing

`wpsc_path_is_too_long()` is pure, so its tests are in the smoke tier, which is the one CI runs.

- `composer test-php`, 65 tests, green
- integration, 53 tests and 148 assertions, green
- reverted the guard and confirmed all three new tests fail
- phpcs clean on every changed line

The limit is `PHP_MAXPATHLEN`, which is what PHP itself reports in the warning: 1024 on macOS, 4096 on Linux. Both tiers size their fixtures from it. My first attempt hardcoded 1200, which passed on macOS and failed in the Linux container, and would have done the same in CI.

### Release Notes

- Fix: stop the error log filling with path length warnings when a request URL is too long to build a cache directory from.

