### PR TITLE
Release WP Super Cache 3.1.2

### DIFF
--- a/.github/workflows/lint-next-version.yml
+++ b/.github/workflows/lint-next-version.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   next-version-tags:
-    # Release PRs are exempt. prepare-release.mjs rewrites every $$next-version$$
+    # Release PRs are exempt. prepare-release.mjs rewrites every 3.1.2
     # to the real version as part of cutting the branch, so the substituted @since
     # lines fail this check on every release. Feature PRs, where a hand-written
     # version is a genuine mistake, are what it exists for.
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - name: Check $$next-version$$ usage in added lines
+      - name: Check 3.1.2 usage in added lines
         run: bash scripts/check-next-version-tag.sh "${{ github.event.pull_request.base.sha }}"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: performance, caching, wp-cache, wp-super-cache, cache
 Requires at least: 6.8
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 3.1.1
+Stable tag: 3.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/scripts/check-next-version-tag.sh
+++ b/scripts/check-next-version-tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Read-only lint for the $$next-version$$ placeholder convention.
+# Read-only lint for the 3.1.2 placeholder convention.
 #
 # Inspects only the lines ADDED in this branch (vs. a base ref) and fails when a
 # new @since / @deprecated / _deprecated_*() introduces either:
@@ -53,20 +53,20 @@ check_line() { # file line content
 	# Deliberate opt-out.
 	case "$line" in *next-version-ok*) return ;; esac
 	# Correct usage — the exact token.
-	case "$line" in *'$$next-version$$'*) return ;; esac
+	case "$line" in *'3.1.2'*) return ;; esac
 
 	# (a) Near-miss placeholder the exact-match release replacer would skip.
 	if printf '%s' "$line" | grep -Eiq \
 		'@(since|deprecated)([[:space:]]+since)?[[:space:]]+[^[:space:]]*next[-_]version|@(since|deprecated)([[:space:]]+since)?[[:space:]]+next([^[:alnum:]]|$)|_deprecated_[a-z]*\([^)]*next[-_]version'
 	then
-		emit "$f" "$ln" 'Malformed next-version placeholder — use the exact token $$next-version$$ (run scripts/replace-next-version-tag.sh -h).'
+		emit "$f" "$ln" 'Malformed next-version placeholder — use the exact token 3.1.2 (run scripts/replace-next-version-tag.sh -h).'
 		return
 	fi
 
 	# (b) Hard-coded version where the placeholder should be used.
 	if printf '%s' "$line" | grep -Eiq '@(since|deprecated)([[:space:]]+since)?[[:space:]]+v?[0-9]+\.[0-9]+'
 	then
-		emit "$f" "$ln" 'Hard-coded version in a new @since/@deprecated — use $$next-version$$ for unreleased code, or add "next-version-ok" if this records a real past release.'
+		emit "$f" "$ln" 'Hard-coded version in a new @since/@deprecated — use 3.1.2 for unreleased code, or add "next-version-ok" if this records a real past release.'
 	fi
 }
 

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -888,7 +888,7 @@ function get_supercache_dir( $blog_id = 0 ) {
  * single-byte LC_CTYPE would lowercase bytes 0xC0-0xDE and corrupt a path that
  * carries raw UTF-8. Matching [A-Z] keeps that out of reach on every version.
  *
- * @since $$next-version$$
+ * @since 3.1.2
  *
  * @param string $uri URI or path fragment.
  * @return string Normalised URI, or '' if $uri is not a string.
@@ -946,7 +946,7 @@ function wpsc_normalize_uri_case( $uri ) {
  * matter run later: the '..' strip, wp_cache_confirm_delete(), and the check that
  * the resolved path sits inside the supercache directory.
  *
- * @since $$next-version$$
+ * @since 3.1.2
  *
  * @param string $path Path from the request.
  * @return string The path unchanged, or '' if it is not one.
@@ -994,7 +994,7 @@ define( 'WPSC_PATH_TOO_LONG_DIR', '.wpsc-path-too-long' );
  * The headroom is because callers append a filename to the directory this
  * measures, 'index.html' or 'meta-<32 hex chars>.meta' being the long ones.
  *
- * @since $$next-version$$
+ * @since 3.1.2
  *
  * @param string $path Path to measure.
  * @return bool True if the path cannot be used.
@@ -1016,7 +1016,7 @@ function wpsc_path_is_too_long( $path ) {
  * wp_parse_url() omits 'path' entirely for a URL like 'https://example.com', so
  * the fallback is not decoration; the old inline version emitted a notice there.
  *
- * @since $$next-version$$
+ * @since 3.1.2
  *
  * @param string $url Absolute URL.
  * @return string Supercache directory for $url, without a trailing slash.

--- a/wp-cache.php
+++ b/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 3.1.1
+ * Version: 3.1.2
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+


### PR DESCRIPTION


> [!IMPORTANT]
> Merging this PR will build and publish the new version automatically as a GitHub release, then deploy the new version on the WordPress.org plugin repository.
>

## WP Super Cache 3.1.2

> [!NOTE]
> These release notes between the two `---` lines will be the final changelog entry for the release. Edit them freely here before merging.
>

### Release Notes

---
- Fix: stop the error log filling with path length warnings when a request URL is too long to build a cache directory from.
- Fix: clear the cache for category, tag and archive pages whose slug contains non-ASCII characters. The delete cache button could not clear those pages either, and now can.
- Fix: clear the cache correctly when saving a post whose slug contains non-ASCII characters.
- Removed the Bad Behavior plugin integration. The upstream plugin is no longer maintained and a long-standing inverted guard meant the integration never actually ran.
- Fix: ignore a post ID of 0 when clearing the cache after a post edit, which could delete the front page cache unexpectedly.
* Split wp-cache.php into per-responsibility inc/ files (#1061) (#1065)
- Fix: cache modern security headers, including Permissions-Policy, the Cross-Origin-Opener/Embedder/Resource-Policy family and the remaining CORS headers, so they are sent on cached responses.
- Fix: honour quality values in the Accept header, so monitoring tools and browsers that list JSON below HTML are served the cached page instead of rebuilding it on every request.
* Fix: hide debug HTML comments in REST and Ajax responses (#1021)
---

### Release

> [!NOTE]
> Click 'Ready for Review', ping the team, review the PR and merge. Upon merging, automation will:
> - Write the release notes above to the changelog
> - Create and tag a new GitHub release
> - Deploy the release to WordPress.org
