### PR TITLE
Stop a cookie named "0" hiding the auth cookies behind it

### DIFF
--- a/tests/php/smoke/WpscAuthCookieValuesTest.php
+++ b/tests/php/smoke/WpscAuthCookieValuesTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for wpsc_get_auth_cookie_values().
+ *
+ * @package automattic/wp-super-cache
+ */
+
+// wp-cache-phase2.php is loaded by the smoke bootstrap (tests/php/bootstrap-smoke.php).
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The smoke tier runs without WordPress, so COOKIEHASH and LOGGED_IN_COOKIE are
+ * undefined and the function falls back to matching the `wordpress_logged_in_`,
+ * `wp-postpass_` and `comment_author_` prefixes. These tests deliberately do not
+ * define those constants: they are process-wide, and defining one here would
+ * change the regex for every other test in the run.
+ *
+ * @covers ::wpsc_get_auth_cookie_values
+ */
+class WpscAuthCookieValuesTest extends TestCase {
+
+	/**
+	 * A logged-in visitor must never produce the anonymous (empty) value.
+	 */
+	public function test_logged_in_cookie_is_collected(): void {
+		$cookies = array( 'wordpress_logged_in_abc123' => 'admin|1|token' );
+		$this->assertSame( 'admin|1|token,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * An anonymous visitor produces the empty string, which is what marks the
+	 * request cacheable as a supercache file.
+	 */
+	public function test_no_auth_cookies_returns_empty_string(): void {
+		$cookies = array(
+			'wordpress_test_cookie' => 'WP Cookie check',
+			'_ga'                   => 'GA1.1.1234',
+		);
+		$this->assertSame( '', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * Regression guard: PHP casts a cookie named "0" to integer key 0, which is
+	 * falsy. The previous `while ( $key = key( $cookies ) )` loop ended there, so
+	 * the auth cookie behind it was never seen and a logged-in visitor was handed
+	 * the anonymous cache key — their page then became the supercache file served
+	 * to everyone.
+	 */
+	public function test_cookie_named_zero_before_auth_cookie_does_not_hide_it(): void {
+		$cookies = array(
+			'0'                          => 'x',
+			'wordpress_logged_in_abc123' => 'admin|1|token',
+		);
+		$this->assertSame( 'admin|1|token,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * The same cookie sitting between two others truncated the scan mid-way.
+	 */
+	public function test_cookie_named_zero_between_cookies_does_not_truncate_scan(): void {
+		$cookies = array(
+			'wordpress_test_cookie'      => 'WP Cookie check',
+			'0'                          => 'x',
+			'wordpress_logged_in_abc123' => 'admin|1|token',
+		);
+		$this->assertSame( 'admin|1|token,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * A post password holder must not share the anonymous key either.
+	 */
+	public function test_cookie_named_zero_before_postpass_cookie(): void {
+		$cookies = array(
+			'0'                  => 'x',
+			'wp-postpass_abc123' => 'hashed-password',
+		);
+		$this->assertSame( 'hashed-password,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * Every matching cookie is collected, in order, so two visitors holding
+	 * different combinations do not collide.
+	 */
+	public function test_multiple_auth_cookies_are_all_collected(): void {
+		$cookies = array(
+			'comment_author_abc123'      => 'Some+One',
+			'0'                          => 'x',
+			'wordpress_logged_in_abc123' => 'admin|1|token',
+		);
+		$this->assertSame( 'Some+One,admin|1|token,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * `Cookie: wordpress_logged_in_abc123[]=x` arrives as an array. It is not a
+	 * valid auth cookie, and concatenating it produced the literal string "Array"
+	 * — a value every sender of that cookie shared. Skip it instead.
+	 */
+	public function test_array_valued_auth_cookie_is_skipped(): void {
+		$cookies = array( 'wordpress_logged_in_abc123' => array( 'x' ) );
+		$this->assertSame( '', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/**
+	 * An array-valued cookie must not stop the scan for the ones behind it.
+	 */
+	public function test_array_valued_cookie_does_not_hide_later_cookies(): void {
+		$cookies = array(
+			'wordpress_logged_in_abc123' => array( 'x' ),
+			'wp-postpass_abc123'         => 'hashed-password',
+		);
+		$this->assertSame( 'hashed-password,', wpsc_get_auth_cookie_values( $cookies ) );
+	}
+
+	/** An empty cookie array is anonymous. */
+	public function test_empty_cookie_array_returns_empty_string(): void {
+		$this->assertSame( '', wpsc_get_auth_cookie_values( array() ) );
+	}
+}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -613,26 +613,7 @@ function wp_cache_get_cookies_values() {
 		return $string;
 	}
 
-	if ( defined( 'COOKIEHASH' ) ) {
-		$cookiehash = preg_quote( constant( 'COOKIEHASH' ) );
-	} else {
-		$cookiehash = '';
-	}
-	$regex = "/^wp-postpass_$cookiehash|^comment_author_$cookiehash";
-	if ( defined( 'LOGGED_IN_COOKIE' ) ) {
-		$regex .= '|^' . preg_quote( constant( 'LOGGED_IN_COOKIE' ) );
-	} else {
-		$regex .= "|^wordpress_logged_in_$cookiehash";
-	}
-	$regex .= '/';
-	while ( $key = key( $_COOKIE ) ) {
-		if ( preg_match( $regex, $key ) ) {
-			wp_cache_debug( 'wp_cache_get_cookies_values: Login/postpass cookie detected' );
-			$string .= $_COOKIE[ $key ] . ',';
-		}
-		next( $_COOKIE );
-	}
-	reset( $_COOKIE );
+	$string = wpsc_get_auth_cookie_values( $_COOKIE );
 
 	// If you use this hook, make sure you update your .htaccess rules with the same conditions
 	$string = do_cacheaction( 'wp_cache_get_cookies_values', $string );
@@ -642,7 +623,10 @@ function wp_cache_get_cookies_values() {
 		is_array( $wpsc_cookies )
 	) {
 		foreach ( $wpsc_cookies as $name ) {
-			if ( isset( $_COOKIE[ $name ] ) ) {
+			// Same reason as wpsc_get_auth_cookie_values(): a cookie sent as name[]=value
+			// arrives as an array, and concatenating it yields the literal string "Array"
+			// for every sender, plus a PHP warning raised inside the output buffer.
+			if ( isset( $_COOKIE[ $name ] ) && is_scalar( $_COOKIE[ $name ] ) ) {
 				wp_cache_debug( "wp_cache_get_cookies_values - found extra cookie: $name" );
 				$string .= $name . '=' . $_COOKIE[ $name ] . ',';
 			}
@@ -654,6 +638,66 @@ function wp_cache_get_cookies_values() {
 	}
 
 	wp_cache_debug( "wp_cache_get_cookies_values: return: $string", 5 );
+	return $string;
+}
+
+/**
+ * Collect the values of the auth cookies that identify a non-anonymous visitor.
+ *
+ * The result is hashed into the cache key, so it decides whether a request is
+ * stored and served as anonymous. Returning an empty string for a visitor who
+ * is in fact logged in (or holds a post password or comment cookie) collapses
+ * their cache key onto the anonymous one, and the personalised page they were
+ * served is written to the supercache file every anonymous visitor then gets.
+ *
+ * Iteration is by foreach for that reason. The previous
+ * `while ( $key = key( $_COOKIE ) )` loop stopped on any falsy key, and PHP
+ * casts a cookie named "0" to integer key 0, which is falsy. A cookie named
+ * "0" sent ahead of the auth cookies ended the scan before it reached them.
+ *
+ * Not to be confused with wpsc_get_auth_cookies(), which answers a different
+ * question: it returns cookie *names*, covers wordpress_ and wordpress_sec_ as
+ * well, and anchors the hash suffix. This one returns the values that go into
+ * the cache key, and matches the same three prefixes the .htaccess rules do.
+ *
+ * The values are concatenated in the order the cookies arrive, so cache keys are
+ * order-sensitive. That is pre-existing behaviour and changing it would move
+ * every existing cache entry.
+ *
+ * @param array $cookies Cookie array, normally $_COOKIE.
+ * @return string Comma-terminated auth cookie values, empty when none match.
+ */
+function wpsc_get_auth_cookie_values( $cookies ) {
+	if ( defined( 'COOKIEHASH' ) ) {
+		$cookiehash = preg_quote( constant( 'COOKIEHASH' ), '/' );
+	} else {
+		$cookiehash = '';
+	}
+	$regex = "/^wp-postpass_$cookiehash|^comment_author_$cookiehash";
+	if ( defined( 'LOGGED_IN_COOKIE' ) ) {
+		// Escaped for the '/' delimiter: a site that redefines LOGGED_IN_COOKIE with
+		// a slash in it would otherwise break the pattern, and preg_match() returning
+		// false makes every logged-in visitor look anonymous.
+		$regex .= '|^' . preg_quote( constant( 'LOGGED_IN_COOKIE' ), '/' );
+	} else {
+		$regex .= "|^wordpress_logged_in_$cookiehash";
+	}
+	$regex .= '/';
+
+	$string = '';
+
+	foreach ( (array) $cookies as $key => $value ) {
+		// A cookie sent as name[]=value arrives as an array and is never a valid auth cookie.
+		if ( ! is_scalar( $value ) ) {
+			continue;
+		}
+
+		if ( preg_match( $regex, (string) $key ) ) {
+			wp_cache_debug( 'wp_cache_get_cookies_values: Login/postpass cookie detected' );
+			$string .= $value . ',';
+		}
+	}
+
 	return $string;
 }
 


### PR DESCRIPTION
`wp_cache_get_cookies_values()` walked `$_COOKIE` like this:

```php
while ( $key = key( $_COOKIE ) ) {
```

PHP casts a cookie named `0` to integer key `0`, which is falsy, so the loop ends there. Any auth cookie sent behind it is never seen, and the function returns the empty string — its marker for an anonymous visitor.

```
buggy loop visited:       ''                                 // "0" first
buggy loop, "0" in middle: '[foo]'                           // scan truncated
foreach visited:          '[0][wordpress_logged_in_abc]'
```

That string is hashed into the cache key at `wp-cache-phase2.php:52`. A logged-in visitor carrying a `0` cookie gets the anonymous key, `:2594` then sets `$supercacheonly`, and the page rendered for them — admin bar, username, their cart — is written to the supercache file every anonymous visitor is served. Nothing in `wp_cache_get_ob()` checks `is_user_logged_in()`, so there is no second line of defence.

### Where it bites

The write side needs `$wp_cache_not_logged_in = 0`. `wpsc_is_caching_user_disabled()` is the only gate that stops it, and it needs the setting to be `2`. Both easy-setup paths force `2` (`inc/admin-ui.php:415`, `rest/class.wp-super-cache-rest-update-settings.php:455`), so a site enabled from the Easy tab is unaffected. `wp-cache-config-sample.php:76` ships `0`, which is what a site enabled from the Advanced tab keeps.

The serve side is not gated by that setting at all. `wp_cache_serve_cache_file()` checks `wp_cache_get_cookies_values() != ''` at `:200`, so in Simple mode a logged-in visitor with a `0` cookie is handed the anonymous supercache file on any configuration. That one fails closed — they see the site logged out rather than someone else's page — but it is the same root cause and it reaches every install.

A cookie named `0` does not have to be deliberate: any script on the domain that sets one breaks cache separation for logged-in visitors on a `= 0` site.

`wpsc_get_auth_cookies()` was already fine; it uses `array_keys()` and `preg_grep()`. Only this one function had the pattern (`grep '= key('` finds nothing else).

### The fix

The scan moves into `wpsc_get_auth_cookie_values()`, which takes the cookie array and iterates with `foreach`. `wp_cache_get_cookies_values()` stays as the memoising wrapper around it, keeping the `do_cacheaction` hook, `$wpsc_cookies` and the `md5()` exactly where they were.

That split is the one already made between `wpsc_get_accept_header()` and `wpsc_parse_accept_header()`, and for the same reason: the `static $string` memo means the function can only be called once per process with a given cookie set, so the scan is untestable while it lives inside the wrapper.

Two smaller guards ride along, both the same failure by another route:

- `Cookie: wordpress_logged_in_HASH[]=x` arrives as an array. It concatenated as the literal string `Array`, so every sender of that cookie shared one bucket. Non-scalar values are skipped.
- The `$wpsc_cookies` loop in the wrapper concatenated the same way and now skips non-scalars too. Guarding one loop and not its neighbour four lines down would leave the function inconsistent with itself.
- `preg_quote()` gets the `/` delimiter. A site redefining `LOGGED_IN_COOKIE` with a slash in it breaks the pattern, and `preg_match()` returning `false` makes every logged-in visitor look anonymous.

`foreach` also fixes two things the original report did not cover: the old loop called `reset()` only *after* iterating, so it started wherever `$_COOKIE`'s internal pointer happened to sit, and it terminated on a cookie named `""` for the same falsy-key reason. Neither is reachable today — nothing else in the tree touches that pointer — but both are now structurally impossible.

### Callers whose behaviour changes

At `:1848` (the `wpcache_do_rebuild` gate) and `:2667` (the `do_createsupercache` gate), `$user_info` is now non-empty for a `0`-cookie logged-in visitor, so the rebuild and the supercache write are correctly skipped. Third-party `do_createsupercache` filters therefore see a different value on those requests than they used to. Intended, but filter-visible.

`inc/htaccess.php:172` matches the same three prefixes against the raw `Cookie` header, so mod_rewrite mode never had the scan bug. That did not protect those sites: the poisoning happens on the PHP write side at `:2611`, which runs in every serving mode.

### Testing

`wpsc_get_auth_cookie_values()` is pure, so its tests are in the smoke tier, the one CI runs.

- `make test`, 74 tests, green (was 65)
- reverted the loop to `while ( $key = key( $cookies ) )` and confirmed 4 failures and 2 errors — the two errors are the array-valued cases hitting `Array to string conversion`
- checked the wrapper end to end with `$_COOKIE = array( '0' => 'x', 'wordpress_logged_in_abc' => 'admin|1|tok' )`: returns `md5( 'admin|1|tok,' )`, was `''`
- `make lint` clean

The integration suite was not run: ports 8888/8889 are held by another project's containers on this machine. Nothing in `tests/php/integration` exercises cookie handling — `HtaccessRulesTest` covers the mod_rewrite cookie conditions, which are Apache-side and untouched here.

### Known coverage gaps

Two lines in this diff are not covered by the suite, both because the smoke tier cannot reach them:

- The `preg_quote( ..., '/' )` change reads `COOKIEHASH` and `LOGGED_IN_COOKIE`, which are process-wide constants the smoke tier cannot define. Testing it means extracting the regex build into a third function taking both as parameters. Left as a follow-up: the change is a no-op for every realistic value (both are hex-suffixed and contain no slash) and only matters for a site that redefines `LOGGED_IN_COOKIE` pathologically, so the risk of it being wrong is close to nil.
- The `$wpsc_cookies` guard sits in the memoising wrapper, which latches `static $string` process-wide and so needs `@runInSeparateProcess` to test.

The wrapper itself has no end-to-end test for the same memo reason. I verified it by hand: with `$_COOKIE = array( '0' => 'x', 'wordpress_logged_in_abc' => 'admin|1|tok' )` it returns `md5( 'admin|1|tok,' )`, where it previously returned `''`. `tests/php/smoke/GetWpCacheKeyTest.php` already has the fixture machinery if someone wants to close that properly.

### Release Notes

- Fix: a cookie named "0" could make a logged-in visitor look anonymous to the cache, so their page was served to everyone.
