### PR TITLE
Escape string settings written into the config file

### DIFF
--- a/tests/php/bootstrap-smoke.php
+++ b/tests/php/bootstrap-smoke.php
@@ -85,6 +85,24 @@ if ( ! function_exists( 'apply_filters' ) ) {
 }
 
 /*
+ * wp-cache-phase2.php calls wp_rand() in several places, the first a smoke test
+ * reaches being the temporary file name in wp_cache_replace_line(). Nothing in the
+ * smoke tier depends on the randomness, only on the function existing.
+ */
+if ( ! function_exists( 'wp_rand' ) ) {
+	/**
+	 * Random integer (test double for WordPress wp_rand()).
+	 *
+	 * @param int $min Lower bound.
+	 * @param int $max Upper bound.
+	 * @return int
+	 */
+	function wp_rand( $min = 0, $max = 4294967295 ) {
+		return random_int( $min, $max );
+	}
+}
+
+/*
  * Load the procedural caching engine. Its functions become callable from tests.
  * require_once keeps test files that also require it (for self-documentation)
  * idempotent.

--- a/tests/php/smoke/WpscCacheSettingTest.php
+++ b/tests/php/smoke/WpscCacheSettingTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Tests for wp_cache_setting()'s config file writes.
+ *
+ * @package automattic/wp-super-cache
+ */
+
+// wp-cache-phase2.php is loaded by the smoke bootstrap (tests/php/bootstrap-smoke.php).
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Config file writes must stay data, not become code.
+ *
+ * The config file is included as PHP before WordPress boots, so any value
+ * written into it is code. These tests round-trip a value through the writer and
+ * back through include, which is the only assertion that actually proves the
+ * file stayed data.
+ *
+ * @covers ::wp_cache_setting
+ */
+class WpscCacheSettingTest extends TestCase {
+
+	/**
+	 * The field every test writes to. The sink is field-agnostic, so one is enough.
+	 *
+	 * Deliberately not cache_path: wp_cache_setting() assigns $GLOBALS[ $field ]
+	 * before writing, and wp_cache_replace_line() puts its temp file in
+	 * $GLOBALS['cache_path'] — writing cache_path here would leave tempnam()
+	 * pointing at a directory that does not exist yet, which falls back to the
+	 * system temp dir and emits a notice PHPUnit turns into an error.
+	 */
+	private const FIELD = 'wpsc_example';
+
+	/**
+	 * Directory holding the config file and the writer's temp files.
+	 *
+	 * @var string
+	 */
+	private string $dir;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->dir = sys_get_temp_dir() . '/wpsc-config-' . uniqid( '', true );
+		mkdir( $this->dir );
+
+		// Neither global exists until a test sets it — the smoke bootstrap loads
+		// wp-cache-phase2.php without a config file — so tearDown unsets rather
+		// than restores. wp_cache_replace_line() reads cache_path for tempnam().
+		$GLOBALS['cache_path']           = $this->dir . '/';
+		$GLOBALS['wp_cache_config_file'] = $this->dir . '/wp-cache-config.php';
+
+		file_put_contents(
+			$GLOBALS['wp_cache_config_file'],
+			"<?php\n\$cache_path = '/original/path/';\n\$" . self::FIELD . " = 'original';\n"
+		);
+	}
+
+	protected function tearDown(): void {
+		foreach ( (array) glob( $this->dir . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $this->dir );
+
+		unset(
+			$GLOBALS['cache_path'],
+			$GLOBALS['wp_cache_config_file'],
+			$GLOBALS[ self::FIELD ],
+			$GLOBALS['wpsc_config_side_effect']
+		);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Include the written config in an isolated scope and hand back the value it
+	 * defined. A statement smuggled into a value would run here, which is the
+	 * point: the marker assertions below detect exactly that.
+	 *
+	 * @return mixed
+	 */
+	private function read_back() {
+		include $GLOBALS['wp_cache_config_file'];
+
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- Defined by the config file included above.
+		return $wpsc_example ?? null;
+	}
+
+	/**
+	 * Values that used to end the string literal early, so that what followed
+	 * became a statement the config file ran on every request.
+	 *
+	 * Each carries a marker assignment rather than anything real: if it runs, the
+	 * value escaped its string.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function breakout_values(): array {
+		return array(
+			'single quote closes the string early' => array( "/var/www/cache/';\$GLOBALS['wpsc_config_side_effect'] = true;" ),
+			'newline starts a new statement'       => array( "/var/www/cache/\n\$GLOBALS['wpsc_config_side_effect'] = true;" ),
+		);
+	}
+
+	/**
+	 * @dataProvider breakout_values
+	 *
+	 * @param string $value Value whose tail would become a statement.
+	 */
+	public function test_value_cannot_smuggle_a_statement( string $value ): void {
+		wp_cache_setting( self::FIELD, $value );
+
+		$written = $this->read_back();
+
+		$this->assertArrayNotHasKey(
+			'wpsc_config_side_effect',
+			$GLOBALS,
+			'Including the written config ran the smuggled statement.'
+		);
+		$this->assertSame( $value, $written );
+	}
+
+	/**
+	 * Values that must survive the write unchanged.
+	 *
+	 * The escape-sequence case is the one input where the escaping could plausibly
+	 * eat itself — a string already containing the literal sequence the newline
+	 * flattening introduces. It cannot, because var_export() escapes the quotes and
+	 * backslash before strtr() runs and strtr() only matches real control bytes,
+	 * but nothing else in the suite pins that ordering.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function round_trip_values(): array {
+		return array(
+			'double quote'        => array( '/var/www/ca"che/' ),
+			'trailing backslash'  => array( 'C:\\inetpub\\cache\\' ),
+			'the escape sequence' => array( '\' . "\n" . \'' ),
+		);
+	}
+
+	/**
+	 * @dataProvider round_trip_values
+	 *
+	 * @param string $value Value that must come back byte-exact.
+	 */
+	public function test_value_round_trips( string $value ): void {
+		wp_cache_setting( self::FIELD, $value );
+
+		$this->assertSame( $value, $this->read_back() );
+	}
+
+	/**
+	 * The entry must occupy exactly one physical line whatever the value holds.
+	 *
+	 * The writer matches '^ *\$field' one line at a time, so a value written across
+	 * two lines loses its tail on the next write of the same field.
+	 */
+	public function test_value_with_newlines_is_written_on_one_line(): void {
+		$before = count( file( $GLOBALS['wp_cache_config_file'] ) );
+
+		wp_cache_setting( self::FIELD, "one\ntwo\r\nthree" );
+
+		$this->assertCount(
+			$before,
+			file( $GLOBALS['wp_cache_config_file'] ),
+			'The value was written across more than one physical line.'
+		);
+		$this->assertSame( "one\ntwo\r\nthree", $this->read_back() );
+	}
+
+	/**
+	 * Rewriting a field whose stored value contained a newline must leave the file
+	 * parseable. This is the failure the one-line rule exists to prevent: the first
+	 * write is valid PHP either way, the second write is where a two-line entry
+	 * orphans its tail and the config stops parsing.
+	 */
+	public function test_overwriting_a_newline_value_leaves_the_file_parseable(): void {
+		wp_cache_setting( self::FIELD, "/var/www/cache/\n\$GLOBALS['wpsc_config_side_effect'] = true;" );
+		wp_cache_setting( self::FIELD, 'plain' );
+
+		$this->assertSame( 'plain', $this->read_back() );
+		$this->assertArrayNotHasKey( 'wpsc_config_side_effect', $GLOBALS );
+	}
+
+	/**
+	 * Null reaches the string branch — is_numeric(), is_bool() and is_array() all
+	 * reject it. The (string) cast keeps it writing as '', which is what the old
+	 * "'$value'" interpolation produced; without the cast var_export() would emit
+	 * the bare token NULL and the config would yield null instead.
+	 */
+	public function test_null_is_written_as_an_empty_string(): void {
+		wp_cache_setting( self::FIELD, null );
+
+		$this->assertStringContainsString( '$' . self::FIELD . " = '';", file_get_contents( $GLOBALS['wp_cache_config_file'] ) );
+		$this->assertSame( '', $this->read_back() );
+	}
+
+	/**
+	 * The escaping must not change what an ordinary value looks like on disk.
+	 * Every legitimate setting is written exactly as before.
+	 */
+	public function test_ordinary_value_is_written_unchanged(): void {
+		wp_cache_setting( self::FIELD, '/var/www/html/wp-content/cache/' );
+
+		$this->assertStringContainsString(
+			'$' . self::FIELD . " = '/var/www/html/wp-content/cache/';",
+			file_get_contents( $GLOBALS['wp_cache_config_file'] )
+		);
+	}
+
+	/** Numeric and boolean settings keep their unquoted form. */
+	public function test_numeric_and_boolean_values_are_unquoted(): void {
+		wp_cache_setting( self::FIELD, 2 );
+		$this->assertStringContainsString( '$' . self::FIELD . ' = 2;', file_get_contents( $GLOBALS['wp_cache_config_file'] ) );
+
+		wp_cache_setting( self::FIELD, true );
+		$this->assertStringContainsString( '$' . self::FIELD . ' = true;', file_get_contents( $GLOBALS['wp_cache_config_file'] ) );
+	}
+}

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1643,7 +1643,37 @@ function wp_cache_setting( $field, $value ) {
 		$text = preg_replace( '/[\s]+/', ' ', $text );
 		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = $text;", $wp_cache_config_file );
 	} else {
-		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = '$value';", $wp_cache_config_file );
+		/*
+		 * var_export() rather than "'$value'". The config file is PHP source, so a
+		 * value carrying a quote closed the string early and a trailing backslash
+		 * escaped the closing quote, either way leaving a line the parser could not
+		 * read back.
+		 *
+		 * Escaping settings values is this function's job, not the caller's. The
+		 * metacharacter strips some callers still run before calling in are older
+		 * belt and braces, not the thing keeping the file readable; a new settings
+		 * field does not need one.
+		 */
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generating PHP source for the config file, which is what var_export() is for.
+		$text = var_export( (string) $value, true );
+
+		/*
+		 * var_export() emits newlines literally, and wp_cache_replace_line() works a
+		 * line at a time: its '^ *\$field' match finds only the first physical line, so
+		 * the next write of the same field replaces that and orphans the tail. The
+		 * orphan stops the file parsing, and it is included before WordPress boots, so
+		 * that is a fatal error rather than a degraded cache. Keep entries to one line:
+		 * a value holding a newline is written as $field = 'one' . "\n" . 'two';
+		 */
+		$text = strtr(
+			$text,
+			array(
+				"\r" => '\' . "\r" . \'',
+				"\n" => '\' . "\n" . \'',
+			)
+		);
+
+		return wp_cache_replace_line( '^ *\$' . $field, "\$$field = $text;", $wp_cache_config_file );
 	}
 }
 


### PR DESCRIPTION
`wp_cache_setting()` built the config line by interpolation:

```php
return wp_cache_replace_line( '^ *\$' . $field, "\$$field = '$value';", $wp_cache_config_file );
```

`wp-content/wp-cache-config.php` is PHP source, included by `advanced-cache.php` before WordPress boots. A value containing a single quote closes the string early and leaves the rest of the line outside it, so the file stops holding the settings it was meant to. A value containing a backslash escapes the closing quote and comes back different from what went in — `C:\inetpub\cache\` wrote a line that would not parse at all.

### Why one path was fine and the other was not

Earlier releases handled this at the call sites, stripping quotes and other metacharacters from individual values before handing them over:

```php
// inc/admin-ui.php:433
$cache_path = preg_replace( '/[ <>\'\"\r\n\t\(\)\$\[\];#]/', '', $new_cache_path );
wp_cache_replace_line( '^ *\$cache_path', "\$cache_path = " . var_export( $cache_path, true ) . ";", ... );
```

There are three copies of that strip — `cache_path` in admin-ui, `wp_cache_debug_ip` and `wp_super_cache_front_page_text` in settings-forms. The REST settings endpoint later grew its own `cache_path` handler, `set_wp_cache_location()`, and never got a fourth. The string settings that never had a strip at all — `wp_cache_debug_username`, `wp_cache_debug_log`, `wp_cache_mobile_browsers`, `wp_cache_mobile_prefixes`, `wp_cache_home_path`, `cache_schedule_type` — went straight through from either side.

### The fix

Escape at the sink with `var_export()`, which is what admin-ui already does once it has stripped the value. Callers cannot get it wrong after that, and the existing strips become belt and braces rather than the only thing keeping the file readable.

One line of production code. Deliberately not a patch to `set_wp_cache_location()` alone: fixing one caller at a time is what left the gap in the first place.

**The output does not change for any legitimate value.** `var_export( $v, true )` and `"'$v'"` are byte-identical unless `$v` contains a quote or a backslash:

```
identical: 10, differs: 0     // real setting values: paths, 'interval', usernames, IPs, log filenames, ''
```

Numeric, boolean and array branches are untouched — `is_numeric()` cannot admit a quote and the array branch already goes through `var_export()`.

### Testing

- `make test`, 71 tests, green (was 65)
- reverted the one-line change and confirmed 2 failures and 1 error, including `ParseError: syntax error, unexpected string content "C:\inetpub\cache\';"` — the test's own config include refusing to parse
- `make lint` clean

The tests round-trip a value through the writer and back through `include`, which is the only assertion that proves the file still holds what was put in it. They write to `$wpsc_example` rather than `$cache_path` because `wp_cache_setting()` assigns `$GLOBALS[ $field ]` before writing and `wp_cache_replace_line()` puts its temp file in `$GLOBALS['cache_path']` — writing `cache_path` in a test points `tempnam()` at a directory that does not exist yet. The escaping is the same for every string field.

`wp_rand()` joins `apply_filters()` as a smoke-tier test double; `wp_cache_replace_line()` uses it to name its temp file.

Integration suite not run — ports 8888/8889 are held by another project's containers on this machine. Nothing under `tests/php/integration` writes config settings.

### Follow-up, not in this PR

`set_wp_cache_location()` still diverges from the admin handler in one harmless way: it checks `if ( $dir == false )` where admin-ui checks `if ( $dir === realpath( '.' ) || false === $dir )`. Worth reconciling.

### Release Notes

- Fix: escape string settings written to the cache config file, so a value containing a quote or a backslash no longer corrupts it.
