### PR TITLE
Sanitise the CDN URLs before they reach asset attributes

### DIFF
--- a/ossdl-cdn.php
+++ b/ossdl-cdn.php
@@ -37,11 +37,19 @@ function scossdl_off_get_options() {
 		$ossdl_off_blog_url = untrailingslashit( apply_filters( 'ossdl_off_blog_url', $ossdl_off_blog_url ) );
 	}
 
+	/*
+	 * esc_url_raw() on the way out of the option, not just on the way in. These
+	 * values are substituted into src/href attributes of every rewritten asset URL
+	 * by scossdl_off_rewriter(), so one carrying a quote or an angle bracket escapes
+	 * the attribute. Sanitising on read means a value stored before this was fixed
+	 * is neutralised without needing a migration.
+	 */
 	$ossdl_off_cdn_url = get_option( 'ossdl_off_cdn_url' );
 	if ( false === $ossdl_off_cdn_url ) {
 		$ossdl_off_cdn_url = untrailingslashit( get_site_url() );
 		add_option( 'ossdl_off_cdn_url', $ossdl_off_cdn_url );
 	}
+	$ossdl_off_cdn_url = esc_url_raw( $ossdl_off_cdn_url );
 
 	$include_dirs = get_option( 'ossdl_off_include_dirs' );
 	if ( false !== $include_dirs ) {
@@ -66,7 +74,10 @@ function scossdl_off_get_options() {
 		$ossdl_cname = '';
 		add_option( 'ossdl_cname', $ossdl_cname );
 	}
-	$ossdl_arr_of_cnames = array_filter( array_map( 'trim', explode( ',', $ossdl_cname ) ) );
+	// Same reason as $ossdl_off_cdn_url above: every entry here is a substitution
+	// target in scossdl_off_rewriter(), and sanitize_text_field() on save leaves
+	// quotes intact.
+	$ossdl_arr_of_cnames = array_filter( array_map( 'esc_url_raw', array_map( 'trim', explode( ',', $ossdl_cname ) ) ) );
 
 	$ossdl_https = intval( get_option( 'ossdl_https' ) );
 }
@@ -237,8 +248,15 @@ function scossdl_off_update() {
 		&& 'update_ossdl_off' === $_POST['action'] // WPCS: sanitization ok.
 		&& wp_verify_nonce( $_POST['_wpnonce'], 'wp-cache' )
 	) {
-		update_option( 'ossdl_off_cdn_url', untrailingslashit( wp_unslash( $_POST['ossdl_off_cdn_url'] ) ) ); // WPSC: sanitization ok.
-		update_option( 'ossdl_off_blog_url', untrailingslashit( wp_unslash( $_POST['ossdl_off_blog_url'] ) ) ); // WPSC: sanitization ok.
+		// esc_url_raw() wraps the unslashed value directly, with untrailingslashit()
+		// applied to the result: it never appends a slash, so the order is free, and
+		// this way the sanitiser is visible to both the reader and phpcs. The isset()
+		// guards are new — a POST without these fields used to raise a notice here.
+		$cdn_url  = isset( $_POST['ossdl_off_cdn_url'] ) ? esc_url_raw( wp_unslash( $_POST['ossdl_off_cdn_url'] ) ) : '';
+		$blog_url = isset( $_POST['ossdl_off_blog_url'] ) ? esc_url_raw( wp_unslash( $_POST['ossdl_off_blog_url'] ) ) : '';
+
+		update_option( 'ossdl_off_cdn_url', untrailingslashit( $cdn_url ) );
+		update_option( 'ossdl_off_blog_url', untrailingslashit( $blog_url ) );
 
 		if ( empty( $_POST['ossdl_off_include_dirs'] ) ) {
 			$include_dirs = implode( ',', scossdl_off_default_inc_dirs() );


### PR DESCRIPTION
`scossdl_off_rewriter()` substitutes `$ossdl_off_cdn_url` and each entry of `$ossdl_arr_of_cnames` into the `src`/`href` of every rewritten asset URL. Neither is URL-sanitised on the way in:

```php
update_option( 'ossdl_off_cdn_url', untrailingslashit( wp_unslash( $_POST['ossdl_off_cdn_url'] ) ) ); // WPSC: sanitization ok.
update_option( 'ossdl_cname', sanitize_text_field( wp_unslash( $_POST['ossdl_cname'] ) ) );           // WPSC: sanitization ok.
```

`sanitize_text_field()` strips tags but leaves quotes alone, and the CDN URL gets nothing at all. A value holding `"`, `<` or `>` is emitted verbatim and ends the attribute early, so the markup on every front-end page is broken from that point on.

The three `// WPSC: sanitization ok.` annotations went with the change. They were asserting something that was not true.

### The fix

`esc_url_raw()`, which is what the rest of the tree already uses. Checked against a real WordPress rather than assumed:

```
https://cdn.example.com                              => https://cdn.example.com
//cdn.example.com                                    => //cdn.example.com
https://cdn.example.com/path?a=1&b=2                 => https://cdn.example.com/path?a=1&b=2
https://cdn.example.com" onerror="alert(1)           => https://cdn.example.com%20onerror=alert(1)
https://cdn.example.com"><script>alert(1)</script>   => https://cdn.example.comscriptalert(1)/script
javascript:alert(1)                                  =>
```

Legitimate values survive byte-identical — protocol-relative `//cdn.example.com` is preserved, and `&` in a query string is not entity-encoded, because `esc_url_raw()` uses the `db` context.

**Applied on read as well as on save.** Saving alone would leave a value stored by an earlier version in place until someone happened to resubmit the form, and there is no migration step for it. Sanitising in `scossdl_off_get_options()` means the stored value is neutralised on the next page load.

`ossdl_off_blog_url` gets the same treatment on save for consistency, though it is only ever used as a `preg_quote()`d search needle and never emitted.

Removing the `// WPSC: sanitization ok.` annotations exposed pre-existing sniff errors underneath — the handler never checked those POST fields existed, so submitting the form without them raised a notice. Both now have `isset()` guards, and `esc_url_raw()` wraps the unslashed value directly with `untrailingslashit()` applied to the result, which reads better and is what the sniff wants. `esc_url_raw()` never appends a slash, so the order is free.

### Testing

Not covered by the suite, and I want to be explicit about that rather than bury it. Both the save path and the read path need a WordPress runtime, so they belong in `tests/php/integration/` — which CI does not run (smoke tier only) and which I could not run locally, because ports 8888/8889 are held by another project's containers on this machine.

What I did instead: verified `esc_url_raw()`'s behaviour empirically against a real WordPress (the table above) rather than reasoning about it from the docs, and confirmed `php -l` on the changed file.

If you want this properly covered before merge, the test belongs alongside the existing `scossdl_off_*` handling and needs `make test-integration` on a machine with those ports free.

### Release Notes

- Fix: sanitise the CDN URL and CNAME settings so a value containing a quote or an angle bracket can no longer break the asset URLs they are substituted into.
