### PR TITLE
Stop a trailing backslash breaking the direct pages config line

### DIFF
--- a/inc/settings-forms.php
+++ b/inc/settings-forms.php
@@ -36,6 +36,15 @@ function wp_update_lock_down() {
 		return 0;
 }
 
+/*
+ * Note on the two var_export() calls below. Each page has already been through a
+ * metacharacter strip that removes $ ( ) ; [ ] ' " and #, but not the backslash.
+ * Wrapping the value as "'$page', " therefore let a trailing backslash escape the
+ * closing quote and break the $cached_direct_pages array literal in
+ * wp-cache-config.php, which is included as PHP before WordPress boots. Building
+ * the element with var_export() closes that, the way wp_cache_setting() does for
+ * scalar settings and wp_cache_sanitize_value() does for the list settings.
+ */
 function wpsc_update_direct_pages() {
 	global $cached_direct_pages, $valid_nonce, $cache_path, $wp_cache_config_file;
 
@@ -49,7 +58,8 @@ function wpsc_update_direct_pages() {
 			$page = str_replace( '..', '', preg_replace( '/[ <>\'\"\r\n\t\(\)\$\[\];#]/', '', $page ) );
 			if ( $page != '' ) {
 				$cached_direct_pages[] = $page;
-				$out .= "'$page', ";
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generating PHP source for the config file.
+				$out .= var_export( (string) $page, true ) . ', ';
 			}
 		}
 	}
@@ -60,7 +70,8 @@ function wpsc_update_direct_pages() {
 			$page = '/' . $page;
 		if ( $page != '/' || false == is_array( $cached_direct_pages ) || in_array( $page, $cached_direct_pages ) == false ) {
 			$cached_direct_pages[] = $page;
-			$out .= "'$page', ";
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Generating PHP source for the config file.
+			$out .= var_export( (string) $page, true ) . ', ';
 
 			@unlink( trailingslashit( ABSPATH . $page ) . "index.html" );
 			// $page is typed by an admin, so its case is whatever they typed, while


### PR DESCRIPTION
`wpsc_update_direct_pages()` builds the `$cached_direct_pages` array literal by hand and writes it with `wp_cache_replace_line()`:

```php
$page = str_replace( '..', '', preg_replace( '/[ <>\'\"\r\n\t\(\)\$\[\];#]/', '', $page ) );
$out .= "'$page', ";
```

The strip removes `$ ( ) ; [ ] ' "` and `#` — but not the backslash. A page ending in one escapes the closing quote, so the literal never closes:

```
ordinary             old  parses      $cached_direct_pages = array( '/about/', '/contact/' );
ordinary             new  parses      $cached_direct_pages = array( '/about/', '/contact/' );
trailing backslash   old  PARSE ERROR $cached_direct_pages = array( '/about\' );
trailing backslash   new  parses      $cached_direct_pages = array( '/about\\' );
inner backslash      old  parses      $cached_direct_pages = array( '/a\b/' );
inner backslash      new  parses      $cached_direct_pages = array( '/a\\b/' );
empty                old  parses      $cached_direct_pages = array(  );
empty                new  parses      $cached_direct_pages = array(  );
```

`wp-cache-config.php` is included as PHP by `advanced-cache.php` before WordPress boots, so a parse error there is a fatal compile error, not a lost setting.

### The fix

Build each element with `var_export()`, the way `wp_cache_setting()` does for scalar settings and `wp_cache_sanitize_value()` does for the list settings. This path does not go through `wp_cache_setting()`, so #1092 does not cover it — it calls `wp_cache_replace_line()` directly with a hand-built string.

Output is byte-identical for ordinary paths. It differs only where the old form wrote something PHP could not read back, or where a backslash sits inside the value and only the bytes change, not the value it yields.

I did not add a helper function for the two call sites: `inc/settings-forms.php` is mid-relocation for #1061 and a new global name there is a cost the two lines do not justify. The reasoning sits in one comment above the function instead.

### Testing

Not covered by the suite. `wpsc_update_direct_pages()` needs a WordPress runtime (`get_option`, `wpsc_delete_files`, `get_supercache_dir`), so it belongs in `tests/php/integration/SettingsFormUpdatersTest.php`, which already characterises its neighbours. CI runs the smoke tier only, and I could not run the integration suite locally — ports 8888/8889 are held by another project's containers on this machine.

What I did instead: replicated the exact line-generation logic in a scratch harness and ran `php -l` over the generated config for each case, which produced the table above. That verifies the generated source, not the surrounding form handling.

`SettingsFormUpdatersTest` is the right home if you want it covered before merge.

### Release Notes

- Fix: a direct page path ending in a backslash no longer breaks the cache config file.
