### PR TITLE
Bump tested up to 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur,
 Tags: performance, caching, wp-cache, wp-super-cache, cache
 Requires at least: 6.8
 Requires PHP: 7.4
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 3.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
`readme.txt` said `Tested up to: 7.0`. WordPress 7.1 is what the plugin has been tested against, and it is what the readme in the wordpress.org SVN trunk now says after the 3.1.3 push.

Without this the repo copy stays at 7.0, and the next release would overwrite the SVN readme and quietly revert the value.

One line, no code.

### Release Notes

- Update the tested-up-to version to WordPress 7.1.
