### PR TITLE
test: cover ignored tracking parameters in cached form actions

### DIFF
--- a/tests/e2e/specs/tracking-parameters.test.ts
+++ b/tests/e2e/specs/tracking-parameters.test.ts
@@ -1,0 +1,33 @@
+import { beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { load as parseDom } from 'cheerio';
+import { updateSettings } from '../lib/plugin-settings';
+import { deleteCacheDirectory, getAuthCookie } from '../lib/plugin-tools';
+import { loadPage } from '../lib/test-tools';
+import { resetEnvironmnt, wpcli } from '../lib/wordpress-tools';
+
+describe( 'ignored tracking parameters', () => {
+	beforeAll( async () => {
+		await resetEnvironmnt();
+		await wpcli( 'plugin', 'activate', 'wp-super-cache' );
+		await updateSettings( await getAuthCookie(), {
+			wp_cache_enabled: true,
+		} );
+		await wpcli(
+			'eval',
+			"wp_cache_setting( 'wpsc_tracking_parameters', array( 'gclid', 'fbclid', 'utm_source' ) ); wp_cache_setting( 'wpsc_ignore_tracking_parameters', 1 );"
+		);
+	} );
+
+	beforeEach( async () => {
+		await deleteCacheDirectory();
+	} );
+
+	test( 'does not cache visitor A click ID in visitor B form action', async () => {
+		const visitorA = await loadPage( '/', { gclid: 'A' } );
+		const visitorB = await loadPage();
+
+		expect( visitorA ).toBe( visitorB );
+		expect( parseDom( visitorA )( '#wpsc-request-uri-form' ).attr( 'action' ) ).toBe( '/' );
+		expect( parseDom( visitorB )( '#wpsc-request-uri-form' ).attr( 'action' ) ).toBe( '/' );
+	} );
+} );

--- a/tests/e2e/tools/mu-test-helpers.php
+++ b/tests/e2e/tools/mu-test-helpers.php
@@ -18,6 +18,16 @@ add_action( 'wp_footer', 'wpsc_test_inject_footer' );
 add_action( 'admin_footer', 'wpsc_test_inject_footer' );
 
 /**
+ * Render a request-derived form action, matching the boundary used by Gravity Forms.
+ */
+function wpsc_test_request_uri_form() {
+	$action = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '/';
+
+	echo '<form id="wpsc-request-uri-form" method="post" action="' . esc_url( $action ) . '"></form>';
+}
+add_action( 'wp_footer', 'wpsc_test_request_uri_form' );
+
+/**
  * Allow per-request login via HTTP header for a single request. Makes testing easier.
  */
 function wpsc_test_header_login() {


### PR DESCRIPTION
## Why

Ignored tracking parameters can map requests from different visitors to the same cached object. If object generation retains the first visitor query in a server-rendered form action, later visitors can submit that visitor campaign data.

Refs #855.

## What

- add a generic request-derived form fixture matching the Gravity Forms boundary without adding a plugin dependency
- exercise Visitor A with gclid=A followed by Visitor B without a click ID
- assert both visitors receive the same cached HTML and a clean form action

Current trunk passes this regression. This PR pins the expected cache boundary before any production change.

## Verification

- focused regression: 1/1 passed with default timeout
- full E2E suite: 7 suites, 29/29 passed under Podman with a 30-second local timeout
- pnpm typecheck
- PHP syntax and PHPCS for the fixture