### PR TITLE
fix: clear legacy cache variants for one URL

### DIFF
--- a/inc/delete-cache-button.php
+++ b/inc/delete-cache-button.php
@@ -157,12 +157,22 @@ function wpsc_delete_cache_directory() {
 		return false;
 	}
 
+	$is_admin = isset( $_POST['admin'] ) && (int) $_POST['admin'] === 1;
+	if ( ! $is_admin ) {
+		$req_path = wp_parse_url( $req_path, PHP_URL_PATH );
+		if ( ! is_string( $req_path ) || '' === $req_path ) {
+			wp_cache_debug( 'wpsc_delete_cache_directory: request path was not valid' );
+			return false;
+		}
+		wpsc_delete_legacy_cache_files( $req_path );
+	}
+
 	// $req_path comes from the browser's REQUEST_URI, so its case is whatever the
 	// visitor's browser sent. Normalise it to the spelling on disk. See #1081.
 	$path = realpath( trailingslashit( get_supercache_dir() . wpsc_normalize_uri_case( str_replace( '..', '', preg_replace( '/:.*$/', '', $req_path ) ) ) ) );
 
 	if ( $path ) {
-		if ( isset( $_POST['admin'] ) && (int) $_POST['admin'] === 1 ) {
+		if ( $is_admin ) {
 			global $file_prefix;
 			wp_cache_debug( 'Cleaning cache for this site.' );
 			wp_cache_clean_cache( $file_prefix );

--- a/tests/php/integration/DeleteUrlCacheCaseTest.php
+++ b/tests/php/integration/DeleteUrlCacheCaseTest.php
@@ -323,33 +323,37 @@ class DeleteUrlCacheCaseTest extends WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * A URL with a query string is a no-op, not a nonce failure.
-	 *
-	 * The admin bar renders the delete button on any URL, so on a site using plain
-	 * permalinks every path is '/?p=123' and on a search page it is '/?s=foo'.
-	 * Those have never had a supercache directory and the delete has always done
-	 * nothing, quietly. What must not happen is the path being emptied before the
-	 * nonce check, because then wpsc_admin_bar_delete_cache() dies with "Problem
-	 * with nonce" on a request whose nonce was perfectly good.
-	 */
-	public function test_query_string_path_is_a_no_op_rather_than_a_nonce_failure() {
+	/** A query-string request deletes every immediate cache file for its path. */
+	public function test_query_string_path_deletes_same_page_cache_files() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
-		foreach ( array( '/?p=123', '/?s=foo' ) as $path ) {
-			$_POST['path']  = $path;
-			$_POST['admin'] = 0;
-			$_POST['nonce'] = wp_create_nonce( 'delete-cache-' . $path . '_0' );
+		$dir   = trailingslashit( get_supercache_dir() . 'some-post' );
+		$child = $dir . 'child/';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+		mkdir( $child, 0777, true );
+		$this->created_dirs[] = $dir;
 
-			$result = wpsc_delete_cache_directory();
-
-			unset( $_POST['path'], $_POST['admin'], $_POST['nonce'] );
-
-			$this->assertNotFalse(
-				$result,
-				"Path {$path} was rejected before the nonce check, so the caller would report a nonce failure that did not happen."
-			);
+		$files = array( 'index.html', 'index.html.gz', 'wp-cache-query.php', 'meta-wp-cache-query.php' );
+		foreach ( $files as $file ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_put_contents -- test fixture.
+			file_put_contents( $dir . $file, 'cached' );
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_put_contents -- test fixture.
+		file_put_contents( $child . 'index.html', 'child cache' );
+
+		$path           = '/some-post/?utm_source=newsletter';
+		$_POST['path']  = $path;
+		$_POST['admin'] = 0;
+		$_POST['nonce'] = wp_create_nonce( 'delete-cache-' . $path . '_0' );
+		$result         = wpsc_delete_cache_directory();
+
+		unset( $_POST['path'], $_POST['admin'], $_POST['nonce'] );
+
+		$this->assertNotFalse( $result );
+		foreach ( $files as $file ) {
+			$this->assertFileDoesNotExist( $dir . $file );
+		}
+		$this->assertFileExists( $child . 'index.html', 'Child path cache was deleted.' );
 	}
 
 	/**

--- a/tests/php/smoke/WpscDeleteLegacyCacheFilesTest.php
+++ b/tests/php/smoke/WpscDeleteLegacyCacheFilesTest.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Regression tests for deleting legacy wp-cache variants by URL path.
+ *
+ * @package automattic/wp-super-cache
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ::wpsc_delete_legacy_cache_files
+ */
+class WpscDeleteLegacyCacheFilesTest extends TestCase {
+
+	/** @var string */
+	private $root;
+
+	/** @var array<string,mixed> */
+	private $saved_globals = array();
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->root = sys_get_temp_dir() . '/wpsc-delete-legacy-' . uniqid( '', true ) . '/';
+		foreach ( array( 'cache/blogs/1/meta', 'cache/blogs/2/meta', 'outside/meta' ) as $dir ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- test fixture.
+			mkdir( $this->root . $dir, 0777, true );
+		}
+
+		$overrides = array(
+			'cache_path'     => $this->root . 'cache/',
+			'blog_cache_dir' => $this->root . 'cache/blogs/1/',
+			'file_prefix'    => 'wp-cache-',
+		);
+
+		foreach ( $overrides as $key => $value ) {
+			$this->saved_globals[ $key ] = array_key_exists( $key, $GLOBALS ) ? $GLOBALS[ $key ] : null;
+			$GLOBALS[ $key ]             = $value;
+		}
+	}
+
+	protected function tearDown(): void {
+		foreach ( $this->saved_globals as $key => $value ) {
+			if ( null === $value ) {
+				unset( $GLOBALS[ $key ] );
+			} else {
+				$GLOBALS[ $key ] = $value;
+			}
+		}
+
+		$this->remove_dir( $this->root );
+		parent::tearDown();
+	}
+
+	/**
+	 * Delete a test directory recursively.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private function remove_dir( $dir ): void {
+		// phpcs:disable WordPress.WP.AlternativeFunctions -- test fixture cleanup.
+		foreach ( (array) glob( $dir . '*' ) as $entry ) {
+			is_dir( $entry ) ? $this->remove_dir( $entry . '/' ) : unlink( $entry );
+		}
+		rmdir( $dir );
+		// phpcs:enable WordPress.WP.AlternativeFunctions
+	}
+
+	/**
+	 * Write one current-format legacy cache payload and metadata pair.
+	 *
+	 * @param string $dir  Blog cache directory.
+	 * @param string $name Unique fixture name.
+	 * @param string $uri  URI stored in metadata.
+	 * @return string Payload path.
+	 */
+	private function write_pair( $dir, $name, $uri ) {
+		$file = 'wp-cache-' . $name . '.php';
+		// phpcs:disable WordPress.WP.AlternativeFunctions -- test fixture.
+		file_put_contents( $dir . $file, '<?php die(); ?>cached' );
+		file_put_contents( $dir . 'meta/' . $file, '<?php die(); ?>' . json_encode( array( 'uri' => $uri ) ) );
+		// phpcs:enable WordPress.WP.AlternativeFunctions
+
+		return $dir . $file;
+	}
+
+	/**
+	 * Write one pre-2015 .html payload and serialized .meta pair.
+	 *
+	 * @param string $dir  Blog cache directory.
+	 * @param string $name Unique fixture name.
+	 * @param string $uri  URI stored in metadata.
+	 * @return string Payload path.
+	 */
+	private function write_old_pair( $dir, $name, $uri ) {
+		$payload = 'wp-cache-' . $name . '.html';
+		$meta    = 'wp-cache-' . $name . '.meta';
+		// phpcs:disable WordPress.WP.AlternativeFunctions, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- test fixture for the historical on-disk format.
+		file_put_contents( $dir . $payload, 'cached' );
+		file_put_contents( $dir . 'meta/' . $meta, serialize( array( 'uri' => $uri ) ) );
+		// phpcs:enable
+
+		return $dir . $payload;
+	}
+
+	/** Same path variants are deleted; other paths and blogs remain. */
+	public function test_deletes_only_same_path_variants_from_current_blog(): void {
+		$blog_dir  = $GLOBALS['blog_cache_dir'];
+		$other_dir = $this->root . 'cache/blogs/2/';
+		$delete    = array(
+			$this->write_pair( $blog_dir, 'bare', 'example.test/page/' ),
+			$this->write_pair( $blog_dir, 'utm', 'example.test/page/?utm_source=newsletter' ),
+			$this->write_pair( $blog_dir, 'click-ids', 'example.test/page/?gclid=1&fbclid=2' ),
+			$this->write_pair( $blog_dir, 'functional', 'example.test/page/?preview=true' ),
+			$this->write_pair( $blog_dir, 'gzip', 'example.test/page/?utm_source=newsletter' ),
+			$this->write_old_pair( $blog_dir, 'old-html', 'example.test/page/?utm_source=old' ),
+		);
+		$keep      = array(
+			$this->write_pair( $blog_dir, 'child', 'example.test/page/child/?utm_source=x' ),
+			$this->write_pair( $blog_dir, 'sibling', 'example.test/page-two/?utm_source=x' ),
+			$this->write_pair( $other_dir, 'other-blog', 'example.test/page/?utm_source=x' ),
+		);
+
+		$malformed = $this->write_pair( $blog_dir, 'malformed', 'example.test/page/' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_put_contents -- malformed test fixture.
+		file_put_contents( $blog_dir . 'meta/' . basename( $malformed ), 'not-json' );
+		$keep[] = $malformed;
+
+		$this->assertSame( 6, wpsc_delete_legacy_cache_files( '/page/' ) );
+
+		foreach ( $delete as $file ) {
+			$this->assertFileDoesNotExist( $file );
+			$meta = str_ends_with( $file, '.html' ) ? str_replace( '.html', '.meta', basename( $file ) ) : basename( $file );
+			$this->assertFileDoesNotExist( dirname( $file ) . '/meta/' . $meta );
+		}
+		foreach ( $keep as $file ) {
+			$this->assertFileExists( $file );
+			$this->assertFileExists( dirname( $file ) . '/meta/' . basename( $file ) );
+		}
+
+		$outside                   = $this->write_pair( $this->root . 'outside/', 'outside', 'example.test/page/' );
+		$GLOBALS['blog_cache_dir'] = $this->root . 'outside/';
+		$this->assertSame( 0, wpsc_delete_legacy_cache_files( '/page/' ) );
+		$this->assertFileExists( $outside );
+	}
+}

--- a/tests/php/smoke/WpscSanitizeCachePathTest.php
+++ b/tests/php/smoke/WpscSanitizeCachePathTest.php
@@ -122,11 +122,8 @@ class WpscSanitizeCachePathTest extends TestCase {
 	 * The admin bar puts the delete button on any URL, so on a site using plain
 	 * permalinks every path is '/?p=123' and on a search page it is '/?s=foo'.
 	 * Rejecting those would empty $req_path and send wpsc_delete_cache_directory()
-	 * down the branch that reports a nonce failure that did not happen. Trimming
-	 * them would leave '/', the site root, which is a real directory and not the
-	 * one the nonce covered. Keeping them means the path simply does not resolve,
-	 * because supercache never names a directory after a query string, and the
-	 * delete is the no-op it has always been.
+	 * down the branch that reports a nonce failure that did not happen. The delete
+	 * handler trims the query only after that nonce has been verified.
 	 */
 	public function test_query_string_is_kept_whole(): void {
 		$this->assertSame( '/?p=123', wpsc_sanitize_cache_path( '/?p=123' ) );

--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -974,15 +974,10 @@ function wpsc_normalize_uri_case( $uri ) {
  * so stripping would turn a delete of /@donncha/ into a delete of /donncha/ and
  * point a nonce-checked operation at a directory the nonce never covered.
  *
- * '?' is on the list for that same reason, inverted. Supercache never names a
- * directory after a query string, so a value carrying one simply fails to
- * resolve and the delete is a no-op, which is what it has always been. Removing
- * the '?s=foo' off a search page instead would leave '/', the site root, which
- * is a real directory and very much not the one the nonce covered. Keeping the
- * query is what makes it harmless. Rejecting the whole value is not an option
- * here either: the admin bar renders this button on any URL, so on a site using
- * plain permalinks every path is '/?p=123', and a rejected path takes the caller
- * down a branch that reports a nonce failure that did not happen.
+ * '?' is on the list because the nonce covers the complete request URI. The
+ * delete handler extracts the path only after verifying that nonce, then clears
+ * every cache key for the path. Rejecting the query here would instead report a
+ * nonce failure when the nonce was valid.
  *
  * Rejecting means the truncation at ':' that wpsc_delete_cache_directory() does
  * afterwards has nothing left to find; it is kept because that function should
@@ -3965,4 +3960,95 @@ function wpsc_apache_request_headers() {
 	}
 
 	return $headers;
+}
+
+/**
+ * Delete wp-cache files whose metadata has the requested path.
+ *
+ * Query strings are deliberately ignored. A page invalidation must remove every
+ * cached representation of that page, including tracking and gzip cache keys.
+ * Only the current blog cache directory is scanned, so multisite neighbours and
+ * child paths are left alone.
+ *
+ * @param string $path Request path without a query string.
+ * @return int Number of cache pairs removed.
+ */
+function wpsc_delete_legacy_cache_files( $path ) {
+	global $blog_cache_dir, $cache_path, $file_prefix;
+
+	if ( ! is_string( $path ) || '' === $path || ! is_string( $file_prefix ) || '' === $file_prefix ) {
+		return 0;
+	}
+
+	$cache_dir = wpsc_get_realpath( $cache_path );
+	$blog_dir  = wpsc_get_realpath( $blog_cache_dir );
+	$meta_dir  = wpsc_get_realpath( $blog_cache_dir . 'meta/' );
+
+	if ( ! $cache_dir || ! $blog_dir || ! $meta_dir ) {
+		return 0;
+	}
+
+	$cache_prefix = $cache_dir . DIRECTORY_SEPARATOR;
+	$blog_prefix  = $blog_dir . DIRECTORY_SEPARATOR;
+	if (
+		( $blog_dir !== $cache_dir && ! str_starts_with( $blog_prefix, $cache_prefix ) ) ||
+		! str_starts_with( $meta_dir . DIRECTORY_SEPARATOR, $blog_prefix )
+	) {
+		return 0;
+	}
+
+	$handle = @opendir( $meta_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Cache directories can disappear concurrently.
+	if ( false === $handle ) {
+		return 0;
+	}
+
+	$path    = wpsc_normalize_uri_case( $path );
+	$deleted = 0;
+	while ( false !== ( $file = readdir( $handle ) ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition -- Stream cache metadata instead of loading an unbounded directory into memory.
+		if ( ! str_starts_with( $file, $file_prefix ) ) {
+			continue;
+		}
+
+		$meta_file = $meta_dir . DIRECTORY_SEPARATOR . $file;
+		if ( ! is_file( $meta_file ) ) {
+			continue;
+		}
+
+		if ( str_ends_with( $file, '.php' ) ) {
+			$cache_file = $blog_prefix . $file;
+			$meta       = json_decode( wp_cache_get_legacy_cache( $meta_file ), true );
+		} elseif ( str_ends_with( $file, '.meta' ) ) {
+			$cache_file = $blog_prefix . substr( $file, 0, -5 ) . '.html';
+			// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions -- Pre-2015 cache metadata used PHP serialization; classes are disabled and files can disappear concurrently.
+			$meta = @unserialize( @file_get_contents( $meta_file ), array( 'allowed_classes' => false ) );
+			// phpcs:enable
+		} else {
+			continue;
+		}
+
+		if ( ! is_file( $cache_file ) ) {
+			continue;
+		}
+
+		if ( ! is_array( $meta ) || ! isset( $meta['uri'] ) || ! is_string( $meta['uri'] ) ) {
+			continue;
+		}
+
+		$uri       = str_starts_with( $meta['uri'], '/' ) ? $meta['uri'] : 'http://' . $meta['uri'];
+		$meta_path = parse_url( $uri, PHP_URL_PATH ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- WordPress is not loaded in phase 2 smoke tests.
+		if ( ! is_string( $meta_path ) || wpsc_normalize_uri_case( $meta_path ) !== $path ) {
+			continue;
+		}
+
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions -- Cache files can disappear between the scan and deletion.
+		$meta_deleted  = @unlink( $meta_file );
+		$cache_deleted = @unlink( $cache_file );
+		// phpcs:enable
+		if ( $cache_deleted || $meta_deleted ) {
+			++$deleted;
+		}
+	}
+	closedir( $handle );
+
+	return $deleted;
 }


### PR DESCRIPTION
Fixes #1086

## Why

The admin-bar Delete Cache action clears the page's supercache directory but leaves legacy wp-cache files for the same URL. Query-string requests expose the gap because they are served by those legacy files, so a URL such as `/some-post/?utm_source=test` remains stale after deletion.

## What Changed

- Keep nonce verification tied to the complete posted URI, then derive its normalized path for invalidation.
- Scan only the current `$blog_cache_dir` metadata and delete cache pairs whose URI has the same path, regardless of query string.
- Support current `.php`/JSON pairs and pre-2015 `.html`/serialized `.meta` pairs.
- Preserve child and sibling paths, malformed metadata, other multisite cache directories, and the separate whole-site deletion branch.

## Verification

- Regression coverage removes bare, UTM, `gclid`, `fbclid`, functional-query, gzip-key, and historical HTML variants for one path.
- Coverage preserves child paths, sibling paths, malformed metadata, cache files outside the configured cache root, and another blog's cache directory.
- The real WordPress integration test posts a query-string path through capability and nonce checks, removes immediate HTML/gzip/wp-cache files, and preserves a child directory.
- PHPCS passes.
- Smoke suite: 85 tests, 134 assertions.
- Integration suite: 53 tests, 152 assertions in both single-site and multisite modes.

### Release Notes

Fixed the Delete Cache action so it clears legacy wp-cache representations for the selected URL, including query-string variants, without recursively clearing child URLs.
