### PR TITLE
Explain when a directly cached file is not generated

### DIFF
--- a/partials/lockdown.php
+++ b/partials/lockdown.php
@@ -46,7 +46,8 @@ if( is_array( $cached_direct_pages ) ) {
 	foreach( $cached_direct_pages as $page ) {
 		if( $page == '' )
 			continue;
-		$generated = '';
+		// phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.Formatting.MultipleStatementAlignment.NotSameWarning
+		$generated = esc_html__( 'Not generated yet', 'wp-super-cache' );
 		if( is_file( ABSPATH . $page . '/index.html' ) )
 			$generated = '<input class="button-secondary" type="Submit" name="deletepage" value="' . $page . '">';
 		$out .= "<tr><td><input type='text' $readonly name='direct_pages[]' size='30' value='$page' /></td><td>$generated</td></tr>";

--- a/tests/php/integration/LockdownPartialTest.php
+++ b/tests/php/integration/LockdownPartialTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for the Directly Cached Files table in the lockdown partial.
+ *
+ * @package automattic/wp-super-cache
+ */
+class LockdownPartialTest extends WP_UnitTestCase {
+
+	/** @var string */
+	private $temp_dir;
+
+	/** @var string */
+	private $direct_page;
+
+	/** @var array<string, array{exists: bool, value: mixed}> */
+	private $saved_globals = array();
+
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'SUBMITDISABLED' ) ) {
+			define( 'SUBMITDISABLED', ' ' );
+		}
+
+		$this->temp_dir    = trailingslashit( get_temp_dir() ) . 'wpsc-lockdown-' . uniqid();
+		$this->direct_page = '/wpsc-direct-' . uniqid() . '/';
+		mkdir( $this->temp_dir, 0700, true );
+
+		foreach ( array( 'cache_path', 'wp_cache_config_file', 'cached_direct_pages', 'valid_nonce' ) as $key ) {
+			$this->saved_globals[ $key ] = array(
+				'exists' => array_key_exists( $key, $GLOBALS ),
+				'value'  => $GLOBALS[ $key ] ?? null,
+			);
+		}
+
+		$GLOBALS['cache_path']           = trailingslashit( $this->temp_dir );
+		$GLOBALS['wp_cache_config_file'] = $this->temp_dir . '/wp-cache-config.php';
+		$GLOBALS['cached_direct_pages']  = array( $this->direct_page );
+		$GLOBALS['valid_nonce']          = false;
+		$_POST                           = array();
+
+		file_put_contents(
+			$GLOBALS['wp_cache_config_file'],
+			"<?php\n\$cached_direct_pages = array();\n"
+		);
+	}
+
+	public function tear_down() {
+		$direct_dir = ABSPATH . trim( $this->direct_page, '/' );
+		if ( is_file( $direct_dir . '/index.html' ) ) {
+			unlink( $direct_dir . '/index.html' );
+		}
+		if ( is_dir( $direct_dir ) ) {
+			rmdir( $direct_dir );
+		}
+
+		foreach ( glob( $this->temp_dir . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $this->temp_dir );
+
+		foreach ( $this->saved_globals as $key => $saved ) {
+			if ( $saved['exists'] ) {
+				$GLOBALS[ $key ] = $saved['value'];
+			} else {
+				unset( $GLOBALS[ $key ] );
+			}
+		}
+		$_POST = array();
+
+		parent::tear_down();
+	}
+
+	/** Render the partial with Directly Cached Files enabled. */
+	private function render_partial() {
+		ob_start();
+		wpsc_render_partial(
+			'lockdown',
+			array(
+				'wp_lock_down'        => '0',
+				'admin_url'           => admin_url( 'options-general.php?page=wpsupercache' ),
+				'cache_enabled'       => true,
+				'super_cache_enabled' => true,
+			)
+		);
+		return ob_get_clean();
+	}
+
+	/** A configured page without a generated file explains why deletion is unavailable. */
+	public function test_ungenerated_direct_page_explains_empty_delete_cell() {
+		$html = $this->render_partial();
+
+		$this->assertStringContainsString( '<td>Not generated yet</td>', $html );
+		$this->assertStringNotContainsString( 'name="deletepage"', $html );
+	}
+
+	/** A generated direct page keeps its existing delete button. */
+	public function test_generated_direct_page_shows_delete_button() {
+		$direct_dir = ABSPATH . trim( $this->direct_page, '/' );
+		mkdir( $direct_dir, 0700, true );
+		file_put_contents( $direct_dir . '/index.html', 'cached' );
+
+		$html = $this->render_partial();
+
+		$this->assertStringContainsString( 'name="deletepage" value="' . $this->direct_page . '"', $html );
+		$this->assertStringNotContainsString( 'Not generated yet', $html );
+	}
+}


### PR DESCRIPTION
Fixes #1098.

The Directly Cached Files table now shows `Not generated yet` when a configured page has no static file. Once the file exists, the existing delete button is shown unchanged.

### Release Notes

- Fix: explain when a directly cached file has not been generated yet.
